### PR TITLE
Fix deploy-pages action SHA in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,4 +39,4 @@ jobs:
           path: docs
 
       - id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac2b3c603fc # v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
## Summary
- Fix invalid pinned commit hash for `actions/deploy-pages` in the docs GitHub Pages workflow
- The SHA `d6db90164ac5ed86f2b6aed7e0febac2b3c603fc` didn't exist; corrected to `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e` (v4.0.5)

## Test plan
- [ ] Docs workflow passes after merge (was failing with "An action could not be found at the URI")

🤖 Generated with [Claude Code](https://claude.com/claude-code)