### PR TITLE
fix(promql): emit group_left() with explicit empty parens

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ promql.div({
 becomes
 
 ```
-http_requests_total{job="api"} / on (instance) group_left http_requests_total{job="api"}
+http_requests_total{job="api"} / on (instance) group_left() http_requests_total{job="api"}
 ```
 
 `composing with rate`

--- a/src/promql.ts
+++ b/src/promql.ts
@@ -89,9 +89,9 @@ export const promql = {
       matching += ` ignoring (${ignoring.join(', ')})`;
     }
     if (groupLeft !== undefined) {
-      matching += groupLeft.length > 0 ? ` group_left (${groupLeft.join(', ')})` : ' group_left';
+      matching += groupLeft.length > 0 ? ` group_left (${groupLeft.join(', ')})` : ' group_left()';
     } else if (groupRight !== undefined) {
-      matching += groupRight.length > 0 ? ` group_right (${groupRight.join(', ')})` : ' group_right';
+      matching += groupRight.length > 0 ? ` group_right (${groupRight.join(', ')})` : ' group_right()';
     }
     return `${left} ${op}${matching} ${right}`;
   },

--- a/src/test/arithmeticBinaryOp.spec.ts
+++ b/src/test/arithmeticBinaryOp.spec.ts
@@ -73,10 +73,34 @@ describe('Operators: Arithmetic Binary Ops with Vector Matching', () => {
       expected: 'metric_a * on (instance) group_left (job, env) metric_b',
     },
 
+    // group_left() with right-hand side starting with ( — regression: bare group_left would cause PromQL parser ambiguity
+    {
+      actual: () =>
+        promql.mul({
+          left: 'kube_pod_info',
+          right: '(k8s_pod_phase{phase="Running"} <= bool 2)',
+          on: ['pod', 'namespace'],
+          groupLeft: [],
+        }),
+      expected: 'kube_pod_info * on (pod, namespace) group_left() (k8s_pod_phase{phase="Running"} <= bool 2)',
+    },
+
     // group_right without labels
     {
       actual: () => promql.div({ left: 'metric_a', right: 'metric_b', on: ['instance'], groupRight: [] }),
       expected: 'metric_a / on (instance) group_right() metric_b',
+    },
+
+    // group_right() with right-hand side starting with ( — regression: bare group_right would cause PromQL parser ambiguity
+    {
+      actual: () =>
+        promql.mul({
+          left: 'kube_pod_info',
+          right: '(k8s_pod_phase{phase="Running"} <= bool 2)',
+          on: ['pod', 'namespace'],
+          groupRight: [],
+        }),
+      expected: 'kube_pod_info * on (pod, namespace) group_right() (k8s_pod_phase{phase="Running"} <= bool 2)',
     },
 
     // group_right with labels

--- a/src/test/arithmeticBinaryOp.spec.ts
+++ b/src/test/arithmeticBinaryOp.spec.ts
@@ -59,7 +59,7 @@ describe('Operators: Arithmetic Binary Ops with Vector Matching', () => {
     // group_left without labels
     {
       actual: () => promql.div({ left: 'metric_a', right: 'metric_b', on: ['instance'], groupLeft: [] }),
-      expected: 'metric_a / on (instance) group_left metric_b',
+      expected: 'metric_a / on (instance) group_left() metric_b',
     },
 
     // group_left with labels
@@ -76,7 +76,7 @@ describe('Operators: Arithmetic Binary Ops with Vector Matching', () => {
     // group_right without labels
     {
       actual: () => promql.div({ left: 'metric_a', right: 'metric_b', on: ['instance'], groupRight: [] }),
-      expected: 'metric_a / on (instance) group_right metric_b',
+      expected: 'metric_a / on (instance) group_right() metric_b',
     },
 
     // group_right with labels
@@ -102,7 +102,7 @@ describe('Operators: Arithmetic Binary Ops with Vector Matching', () => {
           groupLeft: [],
         }),
       expected:
-        'rate(http_requests_total{code="200"}[$__rate_interval]) / on (instance) group_left rate(http_requests_total[$__rate_interval])',
+        'rate(http_requests_total{code="200"}[$__rate_interval]) / on (instance) group_left() rate(http_requests_total[$__rate_interval])',
     },
   ])('Generate PromQL query: $expected', ({ actual, expected }) => {
     expect(actual()).toStrictEqual(expected);


### PR DESCRIPTION
## Summary

`promql.mul` emitted a bare `group_left` / `group_right` when called with `groupLeft: []` / `groupRight: []`. When the right operand starts with `(`, PromQL's parser misinterprets it as the (missing) label list and fails with `unexpected "{" in grouping opts`.

Emitting explicit empty parens (`group_left()` / `group_right()`) disambiguates this. Non-empty cases are unchanged.

### Before

```
some_metric * on (namespace, pod) group_left (k8s_pod_phase{...} <= bool 2)
```

### After

```
some_metric * on (namespace, pod) group_left() (k8s_pod_phase{...} <= bool 2)
```

## Test plan

- [x] `npx jest src/test/arithmeticBinaryOp.spec.ts` — 20/20 pass
- [x] Verified the previously-broken query parses successfully against a real Prometheus instance