### PR TITLE
feat: add comparison binary operators (eq, neq, gt, lt, gte, lte)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,4 +17,5 @@ export type {
   LabelReplace,
   LabelJoin,
   ArithmeticBinaryOpParams,
+  ComparisonBinaryOpParams,
 } from './types';

--- a/src/promql.ts
+++ b/src/promql.ts
@@ -3,6 +3,7 @@ import {
   AggregateWithParameter,
   AggregationParams,
   ArithmeticBinaryOpParams,
+  ComparisonBinaryOpParams,
   LabelJoin,
   LabelReplace,
   LogicalOpParams,
@@ -59,9 +60,9 @@ export const promql = {
   quantile: ({ expr, by, without, parameter }: AggregateWithParameter) =>
     `quantile${promql.byOrWithout({ by, without })}(${parameter}, ${expr})`,
 
-  and: (params: LogicalOpParams) => promql.arithmeticBinaryOp('and', params),
-  or: (params: LogicalOpParams) => promql.arithmeticBinaryOp('or', params),
-  unless: (params: LogicalOpParams) => promql.arithmeticBinaryOp('unless', params),
+  and: (params: LogicalOpParams) => promql.binaryOp('and', params),
+  or: (params: LogicalOpParams) => promql.binaryOp('or', params),
+  unless: (params: LogicalOpParams) => promql.binaryOp('unless', params),
 
   rate: ({ expr, interval = '$__rate_interval' }: Rate) => `rate(${expr}[${interval}])`,
   increase: ({ expr, interval = '$__range' }: Increase) => `increase(${expr}[${interval}])`,
@@ -73,8 +74,8 @@ export const promql = {
   label_join: ({ expr, newLabel, separator = ',', labels }: LabelJoin) =>
     `label_join(${expr}, "${newLabel}", "${separator}", ${labels.map((label) => `"${label}"`).join(', ')})`,
 
-  // Arithmetic binary operators with vector matching
-  arithmeticBinaryOp: (op: string, { left, right, on, ignoring, groupLeft, groupRight }: ArithmeticBinaryOpParams) => {
+  // Shared helper for arithmetic, logical and comparison binary operators with vector matching
+  binaryOp: (op: string, { left, right, on, ignoring, groupLeft, groupRight, bool }: ComparisonBinaryOpParams) => {
     const hasOn = on && on.length > 0;
     const hasIgnoring = ignoring && ignoring.length > 0;
 
@@ -93,13 +94,20 @@ export const promql = {
     } else if (groupRight !== undefined) {
       matching += groupRight.length > 0 ? ` group_right (${groupRight.join(', ')})` : ' group_right()';
     }
-    return `${left} ${op}${matching} ${right}`;
+    return `${left} ${op}${bool ? ' bool' : ''}${matching} ${right}`;
   },
 
-  add: (params: ArithmeticBinaryOpParams) => promql.arithmeticBinaryOp('+', params),
-  sub: (params: ArithmeticBinaryOpParams) => promql.arithmeticBinaryOp('-', params),
-  mul: (params: ArithmeticBinaryOpParams) => promql.arithmeticBinaryOp('*', params),
-  div: (params: ArithmeticBinaryOpParams) => promql.arithmeticBinaryOp('/', params),
-  mod: (params: ArithmeticBinaryOpParams) => promql.arithmeticBinaryOp('%', params),
-  pow: (params: ArithmeticBinaryOpParams) => promql.arithmeticBinaryOp('^', params),
+  add: (params: ArithmeticBinaryOpParams) => promql.binaryOp('+', params),
+  sub: (params: ArithmeticBinaryOpParams) => promql.binaryOp('-', params),
+  mul: (params: ArithmeticBinaryOpParams) => promql.binaryOp('*', params),
+  div: (params: ArithmeticBinaryOpParams) => promql.binaryOp('/', params),
+  mod: (params: ArithmeticBinaryOpParams) => promql.binaryOp('%', params),
+  pow: (params: ArithmeticBinaryOpParams) => promql.binaryOp('^', params),
+
+  eq: (params: ComparisonBinaryOpParams) => promql.binaryOp('==', params),
+  neq: (params: ComparisonBinaryOpParams) => promql.binaryOp('!=', params),
+  gt: (params: ComparisonBinaryOpParams) => promql.binaryOp('>', params),
+  lt: (params: ComparisonBinaryOpParams) => promql.binaryOp('<', params),
+  gte: (params: ComparisonBinaryOpParams) => promql.binaryOp('>=', params),
+  lte: (params: ComparisonBinaryOpParams) => promql.binaryOp('<=', params),
 };

--- a/src/test/comparisonBinaryOp.spec.ts
+++ b/src/test/comparisonBinaryOp.spec.ts
@@ -1,0 +1,177 @@
+import { promql } from '../promql';
+
+// https://prometheus.io/docs/prometheus/latest/querying/operators/#comparison-binary-operators
+// https://prometheus.io/docs/prometheus/latest/querying/operators/#vector-matching
+//
+// Comparison ops currently delegate to the same helper as the arithmetic/logical ops, but they
+// must keep honoring the full vector-matching contract on their own merit. So this file asserts
+// that contract directly against the comparison ops instead of trusting it to hold transitively.
+describe('Operators: Comparison Binary Ops', () => {
+  it.each([
+    // Basic operators
+    {
+      actual: () => promql.eq({ left: 'metric_a', right: 'metric_b' }),
+      expected: 'metric_a == metric_b',
+    },
+    {
+      actual: () => promql.neq({ left: 'metric_a', right: 'metric_b' }),
+      expected: 'metric_a != metric_b',
+    },
+    {
+      actual: () => promql.gt({ left: 'metric_a', right: 'metric_b' }),
+      expected: 'metric_a > metric_b',
+    },
+    {
+      actual: () => promql.lt({ left: 'metric_a', right: 'metric_b' }),
+      expected: 'metric_a < metric_b',
+    },
+    {
+      actual: () => promql.gte({ left: 'metric_a', right: 'metric_b' }),
+      expected: 'metric_a >= metric_b',
+    },
+    {
+      actual: () => promql.lte({ left: 'metric_a', right: 'metric_b' }),
+      expected: 'metric_a <= metric_b',
+    },
+
+    // bool modifier
+    {
+      actual: () => promql.eq({ left: 'metric_a', right: '1', bool: true }),
+      expected: 'metric_a == bool 1',
+    },
+    {
+      actual: () => promql.neq({ left: 'metric_a', right: '0', bool: true }),
+      expected: 'metric_a != bool 0',
+    },
+    {
+      actual: () => promql.gt({ left: 'metric_a', right: '0', bool: true }),
+      expected: 'metric_a > bool 0',
+    },
+    {
+      actual: () => promql.lt({ left: 'metric_a', right: '0', bool: true }),
+      expected: 'metric_a < bool 0',
+    },
+    {
+      actual: () => promql.gte({ left: 'metric_a', right: '1', bool: true }),
+      expected: 'metric_a >= bool 1',
+    },
+    {
+      actual: () => promql.lte({ left: 'metric_a', right: '2', bool: true }),
+      expected: 'metric_a <= bool 2',
+    },
+    // bool: false must not emit the modifier
+    {
+      actual: () => promql.gt({ left: 'metric_a', right: '0', bool: false }),
+      expected: 'metric_a > 0',
+    },
+
+    // on matching
+    {
+      actual: () => promql.gt({ left: 'metric_a', right: 'metric_b', on: ['instance'] }),
+      expected: 'metric_a > on (instance) metric_b',
+    },
+    {
+      actual: () => promql.lt({ left: 'metric_a', right: 'metric_b', on: ['instance', 'job'] }),
+      expected: 'metric_a < on (instance, job) metric_b',
+    },
+
+    // ignoring matching
+    {
+      actual: () => promql.gte({ left: 'metric_a', right: 'metric_b', ignoring: ['job'] }),
+      expected: 'metric_a >= ignoring (job) metric_b',
+    },
+    {
+      actual: () => promql.lte({ left: 'metric_a', right: 'metric_b', ignoring: ['job', 'env'] }),
+      expected: 'metric_a <= ignoring (job, env) metric_b',
+    },
+
+    // on wins over ignoring when both provided
+    {
+      actual: () => promql.eq({ left: 'metric_a', right: 'metric_b', on: ['instance'], ignoring: ['job'] }),
+      expected: 'metric_a == on (instance) metric_b',
+    },
+
+    // bool sits between the operator and the matching clause
+    {
+      actual: () => promql.eq({ left: 'metric_a', right: 'metric_b', bool: true, on: ['instance'] }),
+      expected: 'metric_a == bool on (instance) metric_b',
+    },
+    {
+      actual: () => promql.gte({ left: 'metric_a', right: 'metric_b', bool: true, ignoring: ['job', 'env'] }),
+      expected: 'metric_a >= bool ignoring (job, env) metric_b',
+    },
+
+    // group_left without labels
+    {
+      actual: () => promql.gt({ left: 'metric_a', right: 'metric_b', on: ['instance'], groupLeft: [] }),
+      expected: 'metric_a > on (instance) group_left() metric_b',
+    },
+
+    // group_left with labels
+    {
+      actual: () => promql.gt({ left: 'metric_a', right: 'metric_b', on: ['instance'], groupLeft: ['job'] }),
+      expected: 'metric_a > on (instance) group_left (job) metric_b',
+    },
+    {
+      actual: () => promql.lt({ left: 'metric_a', right: 'metric_b', on: ['instance'], groupLeft: ['job', 'env'] }),
+      expected: 'metric_a < on (instance) group_left (job, env) metric_b',
+    },
+
+    // group_left() with right-hand side starting with ( — regression: bare group_left would cause PromQL parser ambiguity
+    {
+      actual: () =>
+        promql.gte({
+          left: 'kube_pod_info',
+          right: '(k8s_pod_phase{phase="Running"} <= bool 2)',
+          on: ['pod', 'namespace'],
+          groupLeft: [],
+        }),
+      expected: 'kube_pod_info >= on (pod, namespace) group_left() (k8s_pod_phase{phase="Running"} <= bool 2)',
+    },
+
+    // group_right without labels
+    {
+      actual: () => promql.lt({ left: 'metric_a', right: 'metric_b', on: ['instance'], groupRight: [] }),
+      expected: 'metric_a < on (instance) group_right() metric_b',
+    },
+
+    // group_right() with right-hand side starting with ( — regression: bare group_right would cause PromQL parser ambiguity
+    {
+      actual: () =>
+        promql.lte({
+          left: 'kube_pod_info',
+          right: '(k8s_pod_phase{phase="Running"} <= bool 2)',
+          on: ['pod', 'namespace'],
+          groupRight: [],
+        }),
+      expected: 'kube_pod_info <= on (pod, namespace) group_right() (k8s_pod_phase{phase="Running"} <= bool 2)',
+    },
+
+    // group_right with labels
+    {
+      actual: () => promql.neq({ left: 'metric_a', right: 'metric_b', ignoring: ['job'], groupRight: ['env'] }),
+      expected: 'metric_a != ignoring (job) group_right (env) metric_b',
+    },
+
+    // groupLeft wins over groupRight when both provided
+    {
+      actual: () =>
+        promql.gt({ left: 'metric_a', right: 'metric_b', on: ['instance'], groupLeft: ['job'], groupRight: ['env'] }),
+      expected: 'metric_a > on (instance) group_left (job) metric_b',
+    },
+  ])('Generate PromQL query: $expected', ({ actual, expected }) => {
+    expect(actual()).toStrictEqual(expected);
+  });
+
+  it('throws when group_left is used without on/ignoring', () => {
+    expect(() => promql.gt({ left: 'a', right: 'b', groupLeft: [] })).toThrow(
+      'group_left/group_right require an "on" or "ignoring" clause'
+    );
+  });
+
+  it('throws when group_right is used without on/ignoring', () => {
+    expect(() => promql.lt({ left: 'a', right: 'b', groupRight: ['job'] })).toThrow(
+      'group_left/group_right require an "on" or "ignoring" clause'
+    );
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,3 +114,9 @@ export type ArithmeticBinaryOpParams = {
   /** group_right labels for one-to-many matching */
   groupRight?: string[];
 };
+
+/** Parameters for comparison binary operators (==, !=, >, <, >=, <=). */
+export type ComparisonBinaryOpParams = ArithmeticBinaryOpParams & {
+  /** emit the `bool` modifier so the comparison returns 0/1 instead of filtering. */
+  bool?: boolean;
+};


### PR DESCRIPTION
Add first-class PromQL comparison operators so consumers stop appending raw strings like `> bool 0` or `!= 0` onto tsqtsq output.

Each operator supports the optional `bool` modifier and the full vector matching contract (on/ignoring/group_left/group_right) by delegating to the shared binary-op helper. That helper was named `arithmeticBinaryOp` but already backed the logical ops too, and now the comparison ops as well, so it's renamed to the neutral `binaryOp`.