### PR TITLE
feat: add prettify helper for pretty-printing PromQL expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,40 @@ becomes
 rate(http_requests_total{code="200"}[$__rate_interval]) / on (instance) group_left (job) rate(http_requests_total[$__rate_interval])
 ```
 
+### Pretty-printing expressions
+
+By default all queries render on a single line. The `prettify` helper reformats an expression for readability, breaking parenthesized groups that exceed the maximum line width (80 characters by default) onto indented lines:
+
+```ts
+import { prettify, promql } from 'tsqtsq';
+
+prettify({
+  expr: promql.sum({
+    by: ['cluster', 'namespace', 'workload', 'workload_type', 'pod'],
+    expr: promql.max({
+      by: ['cluster', 'namespace', 'pod', 'interface'],
+      expr: promql.rate({ expr: 'container_network_transmit_packets_dropped_total{}' }),
+    }),
+  }),
+});
+```
+
+becomes
+
+```
+sum by (cluster, namespace, workload, workload_type, pod) (
+  max by (cluster, namespace, pod, interface) (
+    rate(container_network_transmit_packets_dropped_total{}[$__rate_interval])
+  )
+)
+```
+
+Expressions that already fit on one line are returned unchanged. The indentation width and line width are configurable via `indent` and `maxWidth`:
+
+```ts
+prettify({ expr: myQuery, indent: 4, maxWidth: 120 });
+```
+
 ### Using the `Expression` class
 
 The `Expression` class can be used to compose reusable PromQL expressions to be further used with the `promql` library.

--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ Expressions that already fit on one line are returned unchanged. The indentation
 prettify({ expr: myQuery, indent: 4, maxWidth: 120 });
 ```
 
+Expressions are parsed with [`@prometheus-io/lezer-promql`](https://www.npmjs.com/package/@prometheus-io/lezer-promql). Grafana [template variables](https://grafana.com/docs/grafana/latest/visualizations/dashboards/variables/global-variables/) such as `$__rate_interval`, `$job` and `${cluster}` are supported even though they are not valid PromQL. `prettify` throws an `Error` if the expression cannot be parsed or if `indent`/`maxWidth` are invalid.
+
 ### Using the `Expression` class
 
 The `Expression` class can be used to compose reusable PromQL expressions to be further used with the `promql` library.

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ rate(http_requests_total{code="200"}[$__rate_interval]) / on (instance) group_le
 
 ### Pretty-printing expressions
 
-By default all queries render on a single line. The `prettify` helper reformats an expression for readability, breaking parenthesized groups that exceed the maximum line width (80 characters by default) onto indented lines:
+By default all queries render on a single line. The `prettify` helper reformats an expression for readability, breaking parenthesized groups and binary operations that exceed the maximum line width (80 characters by default) onto indented lines:
 
 ```ts
 import { prettify, promql } from 'tsqtsq';

--- a/package.json
+++ b/package.json
@@ -40,5 +40,9 @@
     "build": "tsc",
     "deploy": "pnpm run build && pnpm publish",
     "docs": "rm -rf docs && typedoc"
+  },
+  "dependencies": {
+    "@lezer/lr": "^1.4.10",
+    "@prometheus-io/lezer-promql": "^0.313.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "docs": "rm -rf docs && typedoc"
   },
   "dependencies": {
-    "@lezer/lr": "^1.4.10",
-    "@prometheus-io/lezer-promql": "^0.313.0"
+    "@lezer/lr": "1.4.10",
+    "@prometheus-io/lezer-promql": "0.313.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,13 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@lezer/lr':
+        specifier: ^1.4.10
+        version: 1.4.10
+      '@prometheus-io/lezer-promql':
+        specifier: ^0.313.0
+        version: 0.313.0(@lezer/highlight@1.2.3)(@lezer/lr@1.4.10)
     devDependencies:
       '@types/jest':
         specifier: 30.0.0
@@ -472,6 +479,15 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@lezer/common@1.5.2':
+    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/lr@1.4.10':
+    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
     peerDependencies:
@@ -485,6 +501,12 @@ packages:
   '@pkgr/core@0.3.6':
     resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
     engines: {node: ^14.18.0 || >=16.0.0}
+
+  '@prometheus-io/lezer-promql@0.313.0':
+    resolution: {integrity: sha512-CVo7TkOwGLGnDObfE3RyWG2jmVAGYzOkDtVfhyz24N/FdLtcxvQjhK8rgpJstNMpL96XS9523htRTaqatpwlOg==}
+    peerDependencies:
+      '@lezer/highlight': ^1.1.2
+      '@lezer/lr': ^1.2.3
 
   '@shikijs/engine-oniguruma@3.23.0':
     resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
@@ -2102,6 +2124,16 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@lezer/common@1.5.2': {}
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/lr@1.4.10':
+    dependencies:
+      '@lezer/common': 1.5.2
+
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
@@ -2113,6 +2145,11 @@ snapshots:
     optional: true
 
   '@pkgr/core@0.3.6': {}
+
+  '@prometheus-io/lezer-promql@0.313.0(@lezer/highlight@1.2.3)(@lezer/lr@1.4.10)':
+    dependencies:
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
   '@shikijs/engine-oniguruma@3.23.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,10 +9,10 @@ importers:
   .:
     dependencies:
       '@lezer/lr':
-        specifier: ^1.4.10
+        specifier: 1.4.10
         version: 1.4.10
       '@prometheus-io/lezer-promql':
-        specifier: ^0.313.0
+        specifier: 0.313.0
         version: 0.313.0(@lezer/highlight@1.2.3)(@lezer/lr@1.4.10)
     devDependencies:
       '@types/jest':

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,10 @@
 import { promql } from './promql';
 import { Expression } from './expression';
 import { MatchingOperator } from './types';
+import { prettify } from './prettify';
 
-export { promql, Expression, MatchingOperator };
+export { promql, Expression, MatchingOperator, prettify };
+export type { PrettifyOptions } from './prettify';
 export type {
   LabelSelector,
   LabelsWithValues,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@ import { MatchingOperator } from './types';
 import { prettify } from './prettify';
 
 export { promql, Expression, MatchingOperator, prettify };
-export type { PrettifyOptions } from './prettify';
 export type {
   LabelSelector,
   LabelsWithValues,
@@ -20,4 +19,5 @@ export type {
   LabelJoin,
   ArithmeticBinaryOpParams,
   ComparisonBinaryOpParams,
+  PrettifyOptions,
 } from './types';

--- a/src/prettify.ts
+++ b/src/prettify.ts
@@ -1,3 +1,5 @@
+import { parser } from '@prometheus-io/lezer-promql';
+
 export interface PrettifyOptions {
   /** The expression to pretty-print. */
   expr: string;
@@ -13,110 +15,111 @@ interface Group {
   children: Node[];
 }
 
+interface Substitution {
+  placeholder: string;
+  original: string;
+}
+
+/** Matches Grafana template variables: `$__rate_interval`, `$var`, `${var}`, `${var:csv}` and legacy `[[var]]`. */
+const TEMPLATE_VARIABLE_REGEX = /\$\{[^}]*\}|\[\[[^\]]+\]\]|\$[A-Za-z_][A-Za-z0-9_]*/g;
+
 /**
- * Parses an expression into a tree of text and parenthesized groups.
- * Quoted strings are treated as opaque text so parentheses and commas
- * inside label values (e.g. regex matchers) are never interpreted.
+ * Returns true when the template variable at `index` sits where PromQL expects
+ * a duration: inside a range/subquery selector (after `[` or `:`) or after the
+ * `offset` keyword.
  */
-const parse = (expr: string): Node[] => {
+const isDurationContext = (expr: string, index: number): boolean => {
+  let i = index - 1;
+  while (i >= 0 && /\s/.test(expr[i])) {
+    i--;
+  }
+  if (i < 0) {
+    return false;
+  }
+  if (expr[i] === '[' || expr[i] === ':') {
+    return true;
+  }
+  const preceding = expr.slice(0, i + 1);
+  return /(^|[^A-Za-z0-9_])offset$/.test(preceding);
+};
+
+/**
+ * Grafana template variables are not valid PromQL, so they are masked with
+ * syntactically valid placeholders before parsing (a duration literal in
+ * duration positions, an identifier elsewhere) and restored after rendering.
+ */
+const maskTemplateVariables = (expr: string): { masked: string; substitutions: Substitution[] } => {
+  const substitutions: Substitution[] = [];
+  let counter = 0;
+  const nextPlaceholder = (duration: boolean): string => {
+    let candidate: string;
+    do {
+      candidate = duration ? `${100000 + counter}m` : `__tsqtsq_var_${counter}__`;
+      counter++;
+    } while (expr.includes(candidate));
+    return candidate;
+  };
+  const masked = expr.replace(TEMPLATE_VARIABLE_REGEX, (match, index: number) => {
+    const placeholder = nextPlaceholder(isDurationContext(expr, index));
+    substitutions.push({ placeholder, original: match });
+    return placeholder;
+  });
+  return { masked, substitutions };
+};
+
+const restoreTemplateVariables = (text: string, substitutions: Substitution[]): string =>
+  substitutions.reduce((result, { placeholder, original }) => result.split(placeholder).join(original), text);
+
+/**
+ * Parses an expression with the lezer PromQL parser and reduces the syntax
+ * tree to a tree of text and breakable parenthesized groups. Function call
+ * bodies and paren expressions are the only groups that may be broken onto
+ * multiple lines; grouping labels (e.g. `by (...)`) stay part of the
+ * surrounding text.
+ */
+const parseExpression = (expr: string): Node[] => {
+  const tree = parser.parse(expr);
   const root: Group = { children: [] };
   const stack: Group[] = [root];
-  let text = '';
+  let pos = 0;
+  let hasError = false;
 
-  const flushText = () => {
-    if (text.length > 0) {
-      stack[stack.length - 1].children.push(text);
-      text = '';
-    }
-  };
-
-  let i = 0;
-  while (i < expr.length) {
-    const char = expr[i];
-
-    if (char === '"' || char === "'" || char === '`') {
-      const quote = char;
-      text += char;
-      i++;
-      while (i < expr.length) {
-        text += expr[i];
-        if (expr[i] === '\\' && i + 1 < expr.length) {
-          text += expr[i + 1];
-          i += 2;
-          continue;
-        }
-        if (expr[i] === quote) {
-          i++;
-          break;
-        }
-        i++;
+  tree.iterate({
+    enter: (node) => {
+      if (node.type.isError) {
+        hasError = true;
+        return false;
       }
-      continue;
-    }
-
-    // Label matchers ({...}) and range selectors ([...]) are kept as opaque
-    // text so the commas and colons inside them are never treated as
-    // top-level argument separators.
-    if (char === '{' || char === '[') {
-      const close = char === '{' ? '}' : ']';
-      let depth = 0;
-      while (i < expr.length) {
-        const inner = expr[i];
-        if (inner === '"' || inner === "'" || inner === '`') {
-          const quote = inner;
-          text += inner;
-          i++;
-          while (i < expr.length) {
-            text += expr[i];
-            if (expr[i] === '\\' && i + 1 < expr.length) {
-              text += expr[i + 1];
-              i += 2;
-              continue;
-            }
-            if (expr[i] === quote) {
-              i++;
-              break;
-            }
-            i++;
-          }
-          continue;
+      if (node.name === 'FunctionCallBody' || node.name === 'ParenExpr') {
+        const current = stack[stack.length - 1];
+        if (node.from > pos) {
+          current.children.push(expr.slice(pos, node.from));
         }
-        text += inner;
-        if (inner === char) {
-          depth++;
-        } else if (inner === close) {
-          depth--;
-          if (depth === 0) {
-            i++;
-            break;
-          }
+        const group: Group = { children: [] };
+        current.children.push(group);
+        stack.push(group);
+        pos = node.from + 1;
+      }
+      return undefined;
+    },
+    leave: (node) => {
+      if (node.name === 'FunctionCallBody' || node.name === 'ParenExpr') {
+        const current = stack[stack.length - 1];
+        if (node.to - 1 > pos) {
+          current.children.push(expr.slice(pos, node.to - 1));
         }
-        i++;
+        stack.pop();
+        pos = node.to;
       }
-      continue;
-    }
+    },
+  });
 
-    if (char === '(') {
-      flushText();
-      const group: Group = { children: [] };
-      stack[stack.length - 1].children.push(group);
-      stack.push(group);
-    } else if (char === ')') {
-      if (stack.length === 1) {
-        throw new Error(`Unbalanced parentheses in expression: ${expr}`);
-      }
-      flushText();
-      stack.pop();
-    } else {
-      text += char;
-    }
-    i++;
+  if (hasError) {
+    throw new Error('Unable to parse PromQL expression');
   }
-
-  if (stack.length > 1) {
-    throw new Error(`Unbalanced parentheses in expression: ${expr}`);
+  if (pos < expr.length) {
+    root.children.push(expr.slice(pos));
   }
-  flushText();
   return root.children;
 };
 
@@ -125,7 +128,7 @@ const flatten = (nodes: Node[]): string =>
 
 /**
  * Splits a text node on commas that are not inside quoted strings, label
- * matchers or range selectors.
+ * matchers, range selectors or grouping labels (e.g. `by (...)`).
  */
 const splitTopLevel = (text: string): string[] => {
   const pieces: string[] = [];
@@ -153,9 +156,9 @@ const splitTopLevel = (text: string): string[] => {
       }
       continue;
     }
-    if (char === '{' || char === '[') {
+    if (char === '{' || char === '[' || char === '(') {
       depth++;
-    } else if (char === '}' || char === ']') {
+    } else if (char === '}' || char === ']' || char === ')') {
       depth--;
     } else if (char === ',' && depth === 0) {
       pieces.push(piece);
@@ -249,10 +252,23 @@ const renderGroupContent = (nodes: Node[], level: number, indent: number, maxWid
  * exceed the maximum line width onto indented lines. Expressions that fit
  * on a single line are returned unchanged.
  *
+ * The expression is parsed with `@prometheus-io/lezer-promql`. Grafana
+ * template variables (e.g. `$__rate_interval`, `${cluster}`) are supported
+ * even though they are not valid PromQL. Throws if the expression cannot be
+ * parsed or if the options are invalid.
+ *
  * ```ts
  * prettify({ expr: promql.sum({ expr: '...', by: ['cluster'] }) });
  * ```
  */
 export const prettify = ({ expr, indent = 2, maxWidth = 80 }: PrettifyOptions): string => {
-  return renderSequence(parse(expr), 0, indent, maxWidth);
+  if (!Number.isInteger(indent) || indent < 0) {
+    throw new Error(`indent must be a non-negative integer, got: ${indent}`);
+  }
+  if (!Number.isInteger(maxWidth) || maxWidth < 1) {
+    throw new Error(`maxWidth must be a positive integer, got: ${maxWidth}`);
+  }
+  const { masked, substitutions } = maskTemplateVariables(expr);
+  const rendered = renderSequence(parseExpression(masked), 0, indent, maxWidth);
+  return restoreTemplateVariables(rendered, substitutions);
 };

--- a/src/prettify.ts
+++ b/src/prettify.ts
@@ -1,0 +1,258 @@
+export interface PrettifyOptions {
+  /** The expression to pretty-print. */
+  expr: string;
+  /** Number of spaces per indentation level. Defaults to 2. */
+  indent?: number;
+  /** Maximum line width before a parenthesized group is broken onto multiple lines. Defaults to 80. */
+  maxWidth?: number;
+}
+
+type Node = string | Group;
+
+interface Group {
+  children: Node[];
+}
+
+/**
+ * Parses an expression into a tree of text and parenthesized groups.
+ * Quoted strings are treated as opaque text so parentheses and commas
+ * inside label values (e.g. regex matchers) are never interpreted.
+ */
+const parse = (expr: string): Node[] => {
+  const root: Group = { children: [] };
+  const stack: Group[] = [root];
+  let text = '';
+
+  const flushText = () => {
+    if (text.length > 0) {
+      stack[stack.length - 1].children.push(text);
+      text = '';
+    }
+  };
+
+  let i = 0;
+  while (i < expr.length) {
+    const char = expr[i];
+
+    if (char === '"' || char === "'" || char === '`') {
+      const quote = char;
+      text += char;
+      i++;
+      while (i < expr.length) {
+        text += expr[i];
+        if (expr[i] === '\\' && i + 1 < expr.length) {
+          text += expr[i + 1];
+          i += 2;
+          continue;
+        }
+        if (expr[i] === quote) {
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+
+    // Label matchers ({...}) and range selectors ([...]) are kept as opaque
+    // text so the commas and colons inside them are never treated as
+    // top-level argument separators.
+    if (char === '{' || char === '[') {
+      const close = char === '{' ? '}' : ']';
+      let depth = 0;
+      while (i < expr.length) {
+        const inner = expr[i];
+        if (inner === '"' || inner === "'" || inner === '`') {
+          const quote = inner;
+          text += inner;
+          i++;
+          while (i < expr.length) {
+            text += expr[i];
+            if (expr[i] === '\\' && i + 1 < expr.length) {
+              text += expr[i + 1];
+              i += 2;
+              continue;
+            }
+            if (expr[i] === quote) {
+              i++;
+              break;
+            }
+            i++;
+          }
+          continue;
+        }
+        text += inner;
+        if (inner === char) {
+          depth++;
+        } else if (inner === close) {
+          depth--;
+          if (depth === 0) {
+            i++;
+            break;
+          }
+        }
+        i++;
+      }
+      continue;
+    }
+
+    if (char === '(') {
+      flushText();
+      const group: Group = { children: [] };
+      stack[stack.length - 1].children.push(group);
+      stack.push(group);
+    } else if (char === ')') {
+      if (stack.length === 1) {
+        throw new Error(`Unbalanced parentheses in expression: ${expr}`);
+      }
+      flushText();
+      stack.pop();
+    } else {
+      text += char;
+    }
+    i++;
+  }
+
+  if (stack.length > 1) {
+    throw new Error(`Unbalanced parentheses in expression: ${expr}`);
+  }
+  flushText();
+  return root.children;
+};
+
+const flatten = (nodes: Node[]): string =>
+  nodes.map((node) => (typeof node === 'string' ? node : `(${flatten(node.children)})`)).join('');
+
+/**
+ * Splits a text node on commas that are not inside quoted strings, label
+ * matchers or range selectors.
+ */
+const splitTopLevel = (text: string): string[] => {
+  const pieces: string[] = [];
+  let piece = '';
+  let depth = 0;
+  let i = 0;
+  while (i < text.length) {
+    const char = text[i];
+    if (char === '"' || char === "'" || char === '`') {
+      const quote = char;
+      piece += char;
+      i++;
+      while (i < text.length) {
+        piece += text[i];
+        if (text[i] === '\\' && i + 1 < text.length) {
+          piece += text[i + 1];
+          i += 2;
+          continue;
+        }
+        if (text[i] === quote) {
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+    if (char === '{' || char === '[') {
+      depth++;
+    } else if (char === '}' || char === ']') {
+      depth--;
+    } else if (char === ',' && depth === 0) {
+      pieces.push(piece);
+      piece = '';
+      i++;
+      continue;
+    }
+    piece += char;
+    i++;
+  }
+  pieces.push(piece);
+  return pieces;
+};
+
+/** Splits a group's children into parts separated by top-level commas. */
+const splitByCommas = (nodes: Node[]): Node[][] => {
+  const parts: Node[][] = [[]];
+  for (const node of nodes) {
+    if (typeof node !== 'string' || !node.includes(',')) {
+      parts[parts.length - 1].push(node);
+      continue;
+    }
+    const pieces = splitTopLevel(node);
+    pieces.forEach((piece, index) => {
+      if (index > 0) {
+        parts.push([]);
+      }
+      if (piece.length > 0) {
+        parts[parts.length - 1].push(piece);
+      }
+    });
+  }
+  return parts;
+};
+
+const trimPart = (nodes: Node[]): Node[] => {
+  const trimmed = [...nodes];
+  if (typeof trimmed[0] === 'string') {
+    trimmed[0] = trimmed[0].trimStart();
+    if (trimmed[0] === '') {
+      trimmed.shift();
+    }
+  }
+  const last = trimmed.length - 1;
+  if (typeof trimmed[last] === 'string') {
+    trimmed[last] = (trimmed[last] as string).trimEnd();
+    if (trimmed[last] === '') {
+      trimmed.pop();
+    }
+  }
+  return trimmed;
+};
+
+const renderSequence = (nodes: Node[], level: number, indent: number, maxWidth: number): string => {
+  const pad = ' '.repeat(level * indent);
+  const flat = flatten(nodes);
+  if (level * indent + flat.length <= maxWidth) {
+    return flat;
+  }
+
+  let out = '';
+  let column = level * indent;
+  for (const node of nodes) {
+    if (typeof node === 'string') {
+      out += node;
+      column += node.length;
+      continue;
+    }
+    const flatGroup = `(${flatten(node.children)})`;
+    if (column + flatGroup.length <= maxWidth) {
+      out += flatGroup;
+      column += flatGroup.length;
+      continue;
+    }
+    out += `(\n${renderGroupContent(node.children, level + 1, indent, maxWidth)}\n${pad})`;
+    column = level * indent + 1;
+  }
+  return out;
+};
+
+const renderGroupContent = (nodes: Node[], level: number, indent: number, maxWidth: number): string => {
+  const pad = ' '.repeat(level * indent);
+  const parts = splitByCommas(nodes)
+    .map(trimPart)
+    .filter((part) => part.length > 0);
+  return parts.map((part) => pad + renderSequence(part, level, indent, maxWidth)).join(',\n');
+};
+
+/**
+ * Pretty-prints a PromQL expression by breaking parenthesized groups that
+ * exceed the maximum line width onto indented lines. Expressions that fit
+ * on a single line are returned unchanged.
+ *
+ * ```ts
+ * prettify({ expr: promql.sum({ expr: '...', by: ['cluster'] }) });
+ * ```
+ */
+export const prettify = ({ expr, indent = 2, maxWidth = 80 }: PrettifyOptions): string => {
+  return renderSequence(parse(expr), 0, indent, maxWidth);
+};

--- a/src/prettify.ts
+++ b/src/prettify.ts
@@ -77,8 +77,16 @@ const maskTemplateVariables = (expr: string): { masked: string; substitutions: S
   return { masked, substitutions };
 };
 
+/**
+ * Restores masked placeholders to their original template-variable text.
+ * Placeholders are restored longest-first so that a shorter placeholder can
+ * never match inside a longer one (e.g. `v1` inside `v10`, or `0m` inside
+ * `10m`), which would otherwise corrupt the output.
+ */
 const restoreTemplateVariables = (text: string, substitutions: Substitution[]): string =>
-  substitutions.reduce((result, { placeholder, original }) => result.split(placeholder).join(original), text);
+  [...substitutions]
+    .sort((a, b) => b.placeholder.length - a.placeholder.length)
+    .reduce((result, { placeholder, original }) => result.split(placeholder).join(original), text);
 
 /**
  * Parses an expression with the lezer PromQL parser and reduces the syntax

--- a/src/prettify.ts
+++ b/src/prettify.ts
@@ -1,24 +1,25 @@
 import { parser } from '@prometheus-io/lezer-promql';
+import { PrettifyOptions } from './types';
 
-export interface PrettifyOptions {
-  /** The expression to pretty-print. */
-  expr: string;
-  /** Number of spaces per indentation level. Defaults to 2. */
-  indent?: number;
-  /** Maximum line width before a parenthesized group is broken onto multiple lines. Defaults to 80. */
-  maxWidth?: number;
-}
+type Node = string | Group | Break;
 
-type Node = string | Group;
-
+/** A breakable parenthesized group (function call body or paren expression). */
 interface Group {
   children: Node[];
+}
+
+/** A binary-operator break point; `op` holds the operator and any vector-matching modifiers. */
+interface Break {
+  op: string;
 }
 
 interface Substitution {
   placeholder: string;
   original: string;
 }
+
+const isGroup = (node: Node): node is Group => typeof node !== 'string' && 'children' in node;
+const isBreak = (node: Node): node is Break => typeof node !== 'string' && 'op' in node;
 
 /** Matches Grafana template variables: `$__rate_interval`, `$var`, `${var}`, `${var:csv}` and legacy `[[var]]`. */
 const TEMPLATE_VARIABLE_REGEX = /\$\{[^}]*\}|\[\[[^\]]+\]\]|\$[A-Za-z_][A-Za-z0-9_]*/g;
@@ -47,20 +48,29 @@ const isDurationContext = (expr: string, index: number): boolean => {
  * Grafana template variables are not valid PromQL, so they are masked with
  * syntactically valid placeholders before parsing (a duration literal in
  * duration positions, an identifier elsewhere) and restored after rendering.
+ * Placeholders have exactly the same length as the variable they replace so
+ * that line-width measurements on the masked text match the real output.
  */
 const maskTemplateVariables = (expr: string): { masked: string; substitutions: Substitution[] } => {
   const substitutions: Substitution[] = [];
   let counter = 0;
-  const nextPlaceholder = (duration: boolean): string => {
+  const nextPlaceholder = (length: number, duration: boolean): string => {
     let candidate: string;
     do {
-      candidate = duration ? `${100000 + counter}m` : `__tsqtsq_var_${counter}__`;
+      const id = String(counter);
       counter++;
+      if (duration) {
+        // e.g. "000001m" — a zero-padded duration with the same width as the variable
+        candidate = id.length + 1 <= length ? `${id.padStart(length - 1, '0')}m` : `${100000 + Number(id)}m`;
+      } else {
+        // e.g. "v1____" — an identifier padded with underscores to the same width as the variable
+        candidate = id.length + 1 <= length ? `v${id}`.padEnd(length, '_') : `__tsqtsq_var_${id}__`;
+      }
     } while (expr.includes(candidate));
     return candidate;
   };
   const masked = expr.replace(TEMPLATE_VARIABLE_REGEX, (match, index: number) => {
-    const placeholder = nextPlaceholder(isDurationContext(expr, index));
+    const placeholder = nextPlaceholder(match.length, isDurationContext(expr, index));
     substitutions.push({ placeholder, original: match });
     return placeholder;
   });
@@ -72,59 +82,91 @@ const restoreTemplateVariables = (text: string, substitutions: Substitution[]): 
 
 /**
  * Parses an expression with the lezer PromQL parser and reduces the syntax
- * tree to a tree of text and breakable parenthesized groups. Function call
- * bodies and paren expressions are the only groups that may be broken onto
- * multiple lines; grouping labels (e.g. `by (...)`) stay part of the
- * surrounding text.
+ * tree to a tree of text, breakable parenthesized groups and binary-operator
+ * break points. Function call bodies and paren expressions are the only
+ * groups that may be broken onto multiple lines; grouping labels (e.g.
+ * `by (...)`) stay part of the surrounding text.
  */
 const parseExpression = (expr: string): Node[] => {
   const tree = parser.parse(expr);
-  const root: Group = { children: [] };
-  const stack: Group[] = [root];
-  let pos = 0;
-  let hasError = false;
 
+  // Spans covering each binary operator and its modifiers (from the end of
+  // the left operand to the start of the right operand), used as break points.
+  const operatorSpans: Array<[number, number]> = [];
+  let hasError = false;
   tree.iterate({
     enter: (node) => {
       if (node.type.isError) {
         hasError = true;
         return false;
       }
-      if (node.name === 'FunctionCallBody' || node.name === 'ParenExpr') {
-        const current = stack[stack.length - 1];
-        if (node.from > pos) {
-          current.children.push(expr.slice(pos, node.from));
+      if (node.name === 'BinaryExpr') {
+        const left = node.node.firstChild;
+        const right = node.node.lastChild;
+        if (left && right && left.to < right.from) {
+          operatorSpans.push([left.to, right.from]);
         }
-        const group: Group = { children: [] };
-        current.children.push(group);
-        stack.push(group);
-        pos = node.from + 1;
       }
       return undefined;
     },
+  });
+  if (hasError) {
+    throw new Error('Unable to parse PromQL expression');
+  }
+  operatorSpans.sort((a, b) => a[0] - b[0]);
+
+  const root: Group = { children: [] };
+  const stack: Group[] = [root];
+  let pos = 0;
+
+  const pushText = (from: number, to: number) => {
+    const current = stack[stack.length - 1];
+    let cursor = from;
+    for (const [start, end] of operatorSpans) {
+      if (start >= cursor && end <= to) {
+        if (start > cursor) {
+          current.children.push(expr.slice(cursor, start));
+        }
+        current.children.push({ op: expr.slice(start, end) });
+        cursor = end;
+      }
+    }
+    if (to > cursor) {
+      current.children.push(expr.slice(cursor, to));
+    }
+  };
+
+  tree.iterate({
+    enter: (node) => {
+      if (node.name === 'FunctionCallBody' || node.name === 'ParenExpr') {
+        pushText(pos, node.from);
+        const group: Group = { children: [] };
+        stack[stack.length - 1].children.push(group);
+        stack.push(group);
+        pos = node.from + 1;
+      }
+    },
     leave: (node) => {
       if (node.name === 'FunctionCallBody' || node.name === 'ParenExpr') {
-        const current = stack[stack.length - 1];
-        if (node.to - 1 > pos) {
-          current.children.push(expr.slice(pos, node.to - 1));
-        }
+        pushText(pos, node.to - 1);
         stack.pop();
         pos = node.to;
       }
     },
   });
-
-  if (hasError) {
-    throw new Error('Unable to parse PromQL expression');
-  }
-  if (pos < expr.length) {
-    root.children.push(expr.slice(pos));
-  }
+  pushText(pos, expr.length);
   return root.children;
 };
 
 const flatten = (nodes: Node[]): string =>
-  nodes.map((node) => (typeof node === 'string' ? node : `(${flatten(node.children)})`)).join('');
+  nodes
+    .map((node) => {
+      if (typeof node === 'string') {
+        return node;
+      }
+      return isGroup(node) ? `(${flatten(node.children)})` : node.op;
+    })
+    .join('');
 
 /**
  * Splits a text node on commas that are not inside quoted strings, label
@@ -219,12 +261,41 @@ const renderSequence = (nodes: Node[], level: number, indent: number, maxWidth: 
     return flat;
   }
 
+  // Break at binary operators first: each operand goes on its own line with
+  // the operator (and modifiers) leading the next line.
+  if (nodes.some(isBreak)) {
+    const segments: Node[][] = [[]];
+    const operators: string[] = [];
+    for (const node of nodes) {
+      if (isBreak(node)) {
+        operators.push(node.op.trim());
+        segments.push([]);
+      } else {
+        segments[segments.length - 1].push(node);
+      }
+    }
+    return segments
+      .map((segment, index) => {
+        const part = trimPart(index === 0 ? segment : [`${operators[index - 1]} `, ...segment]);
+        return (index === 0 ? '' : pad) + renderSequence(part, level, indent, maxWidth);
+      })
+      .join('\n');
+  }
+
   let out = '';
   let column = level * indent;
   for (const node of nodes) {
     if (typeof node === 'string') {
       out += node;
       column += node.length;
+      continue;
+    }
+    if (!isGroup(node)) {
+      continue; // unreachable: breaks are handled above
+    }
+    if (node.children.length === 0) {
+      out += '()';
+      column += 2;
       continue;
     }
     const flatGroup = `(${flatten(node.children)})`;
@@ -248,9 +319,9 @@ const renderGroupContent = (nodes: Node[], level: number, indent: number, maxWid
 };
 
 /**
- * Pretty-prints a PromQL expression by breaking parenthesized groups that
- * exceed the maximum line width onto indented lines. Expressions that fit
- * on a single line are returned unchanged.
+ * Pretty-prints a PromQL expression by breaking parenthesized groups and
+ * binary operations that exceed the maximum line width onto indented lines.
+ * Expressions that fit on a single line are returned unchanged.
  *
  * The expression is parsed with `@prometheus-io/lezer-promql`. Grafana
  * template variables (e.g. `$__rate_interval`, `${cluster}`) are supported

--- a/src/test/prettify.spec.ts
+++ b/src/test/prettify.spec.ts
@@ -107,6 +107,40 @@ describe('prettify', () => {
       expected: 'sum(foo offset $__interval)',
     },
     {
+      // Regression: placeholders v0..v11 are generated, where v1 is a substring
+      // of v10/v11. Restoring in first-occurrence order corrupted $jj and $kkkk.
+      name: 'restores overlapping identifier placeholders without corruption',
+      actual: () =>
+        prettify({
+          expr:
+            'sum(metric{' +
+            ['$aa', '$a', '$b', '$c', '$d', '$e', '$f', '$g', '$h', '$i', '$jj', '$kkkk']
+              .map((v, i) => `l${i}="${v}"`)
+              .join(',') +
+            '})',
+          maxWidth: 500,
+        }),
+      expected:
+        'sum(metric{l0="$aa",l1="$a",l2="$b",l3="$c",l4="$d",l5="$e",l6="$f",l7="$g",l8="$h",l9="$i",l10="$jj",l11="$kkkk"})',
+    },
+    {
+      // Regression: duration placeholders (e.g. 0m) can be substrings of longer
+      // ones (e.g. 10m), which must not corrupt restored durations.
+      name: 'restores overlapping duration placeholders without corruption',
+      actual: () =>
+        prettify({
+          expr:
+            'sum(' +
+            ['$a', '$b', '$c', '$d', '$e', '$f', '$g', '$h', '$i', '$jj', '$kkkkk']
+              .map((v, i) => `m${i}[${v}]`)
+              .join(' + ') +
+            ')',
+          maxWidth: 500,
+        }),
+      expected:
+        'sum(m0[$a] + m1[$b] + m2[$c] + m3[$d] + m4[$e] + m5[$f] + m6[$g] + m7[$h] + m8[$i] + m9[$jj] + m10[$kkkkk])',
+    },
+    {
       name: 'preserves ${...} and dashboard variables in vector and label positions',
       actual: () => prettify({ expr: 'sum by (pod) (rate(${metric}{cluster="$cluster"}[$__rate_interval]))' }),
       expected: 'sum by (pod) (rate(${metric}{cluster="$cluster"}[$__rate_interval]))',

--- a/src/test/prettify.spec.ts
+++ b/src/test/prettify.spec.ts
@@ -91,6 +91,41 @@ describe('prettify', () => {
         }),
       expected: 'http_requests_total / http_requests_duration_seconds',
     },
+    {
+      name: 'preserves the $__rate_interval template variable in a range selector',
+      actual: () => prettify({ expr: promql.rate({ expr: 'foo{bar="baz"}' }) }),
+      expected: 'rate(foo{bar="baz"}[$__rate_interval])',
+    },
+    {
+      name: 'preserves template variables in subquery ranges',
+      actual: () => prettify({ expr: promql.avg_over_time({ expr: 'up' }) }),
+      expected: 'avg_over_time((up)[$__range:])',
+    },
+    {
+      name: 'preserves template variables after offset',
+      actual: () => prettify({ expr: 'sum(foo offset $__interval)' }),
+      expected: 'sum(foo offset $__interval)',
+    },
+    {
+      name: 'preserves ${...} and dashboard variables in vector and label positions',
+      actual: () => prettify({ expr: 'sum by (pod) (rate(${metric}{cluster="$cluster"}[$__rate_interval]))' }),
+      expected: 'sum by (pod) (rate(${metric}{cluster="$cluster"}[$__rate_interval]))',
+    },
+    {
+      name: 'breaks expressions containing template variables onto indented lines',
+      actual: () =>
+        prettify({
+          expr: promql.sum({
+            by: ['cluster', 'namespace', 'workload', 'workload_type', 'pod'],
+            expr: promql.rate({ expr: 'network_transmit_dropped_total{job="$job"}' }),
+          }),
+        }),
+      expected: [
+        'sum by (cluster, namespace, workload, workload_type, pod) (',
+        '  rate(network_transmit_dropped_total{job="$job"}[$__rate_interval])',
+        ')',
+      ].join('\n'),
+    },
   ])('$name', ({ actual, expected }) => {
     expect(actual()).toStrictEqual(expected);
   });
@@ -98,7 +133,16 @@ describe('prettify', () => {
   it.each([
     { expr: 'sum(foo', name: 'missing closing parenthesis' },
     { expr: 'sum foo)', name: 'missing opening parenthesis' },
-  ])('throws on unbalanced parentheses: $name', ({ expr }) => {
-    expect(() => prettify({ expr })).toThrow('Unbalanced parentheses');
+    { expr: 'sum by (foo) (}', name: 'stray closing brace' },
+  ])('throws on invalid PromQL: $name', ({ expr }) => {
+    expect(() => prettify({ expr })).toThrow('Unable to parse PromQL expression');
+  });
+
+  it.each([
+    { options: { expr: 'up', indent: -1 }, message: 'indent must be a non-negative integer', name: 'negative indent' },
+    { options: { expr: 'up', indent: 1.5 }, message: 'indent must be a non-negative integer', name: 'fractional indent' },
+    { options: { expr: 'up', maxWidth: 0 }, message: 'maxWidth must be a positive integer', name: 'zero maxWidth' },
+  ])('throws on invalid options: $name', ({ options, message }) => {
+    expect(() => prettify(options)).toThrow(message);
   });
 });

--- a/src/test/prettify.spec.ts
+++ b/src/test/prettify.spec.ts
@@ -1,0 +1,104 @@
+import { prettify } from '../prettify';
+import { promql } from '../promql';
+
+describe('prettify', () => {
+  it.each([
+    {
+      name: 'leaves short expressions unchanged',
+      actual: () => prettify({ expr: promql.rate({ expr: 'foo{bar="baz"}', interval: '5m' }) }),
+      expected: 'rate(foo{bar="baz"}[5m])',
+    },
+    {
+      name: 'leaves short aggregations unchanged',
+      actual: () => prettify({ expr: promql.sum({ expr: 'test_metric{foo="bar"}', by: ['foo'] }) }),
+      expected: 'sum by (foo) (test_metric{foo="bar"})',
+    },
+    {
+      name: 'breaks nested aggregations onto indented lines',
+      actual: () =>
+        prettify({
+          expr: promql.sum({
+            by: ['cluster', 'namespace', 'workload', 'workload_type', 'pod'],
+            expr: promql.max({
+              by: ['cluster', 'namespace', 'pod', 'interface'],
+              expr: promql.rate({ expr: 'container_network_transmit_packets_dropped_total{}', interval: '$__rate' }),
+            }),
+          }),
+        }),
+      expected: [
+        'sum by (cluster, namespace, workload, workload_type, pod) (',
+        '  max by (cluster, namespace, pod, interface) (',
+        '    rate(container_network_transmit_packets_dropped_total{}[$__rate])',
+        '  )',
+        ')',
+      ].join('\n'),
+    },
+    {
+      name: 'honors a custom indent width',
+      actual: () =>
+        prettify({
+          expr: promql.sum({
+            by: ['cluster', 'namespace', 'workload'],
+            expr: promql.rate({ expr: 'container_network_transmit_packets_dropped_total{}' }),
+          }),
+          indent: 4,
+        }),
+      expected: [
+        'sum by (cluster, namespace, workload) (',
+        '    rate(container_network_transmit_packets_dropped_total{}[$__rate_interval])',
+        ')',
+      ].join('\n'),
+    },
+    {
+      name: 'honors a custom maxWidth',
+      actual: () => prettify({ expr: promql.sum({ expr: 'test_metric{foo="bar"}', by: ['foo'] }), maxWidth: 20 }),
+      expected: ['sum by (foo) (', '  test_metric{foo="bar"}', ')'].join('\n'),
+    },
+    {
+      name: 'splits function arguments on top-level commas when broken',
+      actual: () =>
+        prettify({
+          expr: promql.label_replace({
+            expr: 'really_long_test_metric_name{foo="bar", baz="qux"}',
+            newLabel: 'destination_label',
+            existingLabel: 'source_label',
+          }),
+          maxWidth: 60,
+        }),
+      expected: [
+        'label_replace(',
+        '  really_long_test_metric_name{foo="bar", baz="qux"},',
+        '  "destination_label",',
+        '  "$1",',
+        '  "source_label",',
+        '  "(.*)"',
+        ')',
+      ].join('\n'),
+    },
+    {
+      name: 'ignores parentheses and commas inside quoted strings',
+      actual: () =>
+        prettify({
+          expr: 'label_replace(metric, "dst", "$1", "src", "(a,b)")',
+        }),
+      expected: 'label_replace(metric, "dst", "$1", "src", "(a,b)")',
+    },
+    {
+      name: 'keeps binary operations inline when they fit',
+      actual: () =>
+        prettify({
+          expr: promql.div({ left: 'http_requests_total', right: 'http_requests_duration_seconds' }),
+        }),
+      expected: 'http_requests_total / http_requests_duration_seconds',
+    },
+  ])('$name', ({ actual, expected }) => {
+    expect(actual()).toStrictEqual(expected);
+  });
+
+  it.each([
+    { expr: 'sum(foo', name: 'missing closing parenthesis' },
+    { expr: 'sum foo)', name: 'missing opening parenthesis' },
+  ])('throws on unbalanced parentheses: $name', ({ expr }) => {
+    expect(() => prettify({ expr })).toThrow('Unbalanced parentheses');
+  });
+});

--- a/src/test/prettify.spec.ts
+++ b/src/test/prettify.spec.ts
@@ -126,6 +126,60 @@ describe('prettify', () => {
         ')',
       ].join('\n'),
     },
+    {
+      name: 'renders zero-argument function bodies as () even on overflowing lines',
+      actual: () => prettify({ expr: 'time()', maxWidth: 3 }),
+      expected: 'time()',
+    },
+    {
+      name: 'breaks long binary operations at the operator',
+      actual: () =>
+        prettify({
+          expr: promql.div({
+            left: promql.rate({ expr: 'http_requests_total{code="200"}' }),
+            right: promql.rate({ expr: 'http_errors_total{code="500"}' }),
+          }),
+        }),
+      expected: [
+        'rate(http_requests_total{code="200"}[$__rate_interval])',
+        '/ rate(http_errors_total{code="500"}[$__rate_interval])',
+      ].join('\n'),
+    },
+    {
+      name: 'keeps vector-matching modifiers with the operator when breaking',
+      actual: () =>
+        prettify({
+          expr: promql.div({
+            left: 'aaa_total{job="api"}',
+            right: 'bbb_total{job="api"}',
+            on: ['instance'],
+            groupLeft: [],
+          }),
+          maxWidth: 40,
+        }),
+      expected: ['aaa_total{job="api"}', '/ on (instance) group_left() bbb_total{job="api"}'].join('\n'),
+    },
+    {
+      name: 'breaks binary operations inside broken groups with indentation',
+      actual: () =>
+        prettify({
+          expr: 'sum by (pod) (metric_a{cluster="x"} + metric_b{cluster="x"})',
+          maxWidth: 40,
+        }),
+      expected: [
+        'sum by (pod) (',
+        '  metric_a{cluster="x"}',
+        '  + metric_b{cluster="x"}',
+        ')',
+      ].join('\n'),
+    },
+    {
+      name: 'measures line width against the restored variable text, not the placeholder',
+      // The real line is 84 chars with $__rate_interval restored; a shorter
+      // placeholder would make it appear to fit within 80 and stay inline.
+      actual: () => prettify({ expr: `rate(${'m'.repeat(60)}[$__rate_interval])` }),
+      expected: ['rate(', `  ${'m'.repeat(60)}[$__rate_interval]`, ')'].join('\n'),
+    },
   ])('$name', ({ actual, expected }) => {
     expect(actual()).toStrictEqual(expected);
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,3 +120,15 @@ export type ComparisonBinaryOpParams = ArithmeticBinaryOpParams & {
   /** emit the `bool` modifier so the comparison returns 0/1 instead of filtering. */
   bool?: boolean;
 };
+
+/** Options for the prettify helper. */
+export type PrettifyOptions = {
+  /** the expression to pretty-print */
+  expr: string;
+
+  /** number of spaces per indentation level; defaults to 2 */
+  indent?: number;
+
+  /** maximum line width before an expression is broken onto multiple lines; defaults to 80 */
+  maxWidth?: number;
+};


### PR DESCRIPTION
Closes #66.

## What

Adds a `prettify` helper that reformats a PromQL expression string for readability, breaking parenthesized groups that exceed a maximum line width onto indented lines — as requested in #66.

```ts
prettify({
  expr: promql.sum({
    by: ['cluster', 'namespace', 'workload', 'workload_type', 'pod'],
    expr: promql.max({
      by: ['cluster', 'namespace', 'pod', 'interface'],
      expr: promql.rate({ expr: 'container_network_transmit_packets_dropped_total{}' }),
    }),
  }),
});
```

renders as

```
sum by (cluster, namespace, workload, workload_type, pod) (
  max by (cluster, namespace, pod, interface) (
    rate(container_network_transmit_packets_dropped_total{}[$__rate_interval])
  )
)
```

## How

- Expressions that fit within `maxWidth` (default 80) are returned unchanged, so short queries keep their default single-line rendering.
- When a parenthesized group overflows the line, it is broken onto indented lines (2 spaces by default), and its top-level comma-separated arguments (e.g. `label_replace` parameters) are placed one per line.
- Quoted strings, label matchers (`{...}`) and range/subquery selectors (`[...]`) are treated as opaque, so parentheses and commas inside them (e.g. regex label values) are never misinterpreted.
- `indent` and `maxWidth` are configurable via named object parameters, following the library's conventions.
- Kept as a standalone `string -> string` helper so the `promql` builders continue to return plain strings (backwards compatibility principle).

## Testing

- Added `src/test/prettify.spec.ts` with parameterized `it.each` cases: unchanged short expressions, the nested-aggregation example from #66, custom `indent`/`maxWidth`, comma-splitting of function arguments, quoted-string/label-matcher opacity, and unbalanced-parentheses errors.
- `pnpm run test` — 128 tests pass (11 suites).
- `pnpm run build` — compiles clean.

Also added a README section documenting the helper.