### PR TITLE
Add precendence preserving parentheses

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ promql.div({ left: 'http_requests_total', right: 'http_requests_duration_seconds
 becomes
 
 ```
-http_requests_total / http_requests_duration_seconds
+(http_requests_total / http_requests_duration_seconds)
 ```
 
 `vector matching with on`
@@ -130,7 +130,7 @@ promql.div({
 becomes
 
 ```
-http_requests_total{job="api"} / on (instance) group_left() http_requests_total{job="api"}
+(http_requests_total{job="api"} / on (instance) group_left() http_requests_total{job="api"})
 ```
 
 `composing with rate`
@@ -147,7 +147,7 @@ promql.div({
 becomes
 
 ```
-rate(http_requests_total{code="200"}[$__rate_interval]) / on (instance) group_left (job) rate(http_requests_total[$__rate_interval])
+(rate(http_requests_total{code="200"}[$__rate_interval]) / on (instance) group_left (job) rate(http_requests_total[$__rate_interval]))
 ```
 
 ### Pretty-printing expressions

--- a/docs-src/examples.md
+++ b/docs-src/examples.md
@@ -35,7 +35,7 @@ promql.div({
   right: 'node_memory_MemTotal_bytes',
   on: ['instance'],
 });
-// => node_memory_MemAvailable_bytes / on (instance) node_memory_MemTotal_bytes
+// => (node_memory_MemAvailable_bytes / on (instance) node_memory_MemTotal_bytes)
 ```
 
 ## Label Operations

--- a/jsonnet/promql.libsonnet
+++ b/jsonnet/promql.libsonnet
@@ -154,7 +154,7 @@ local promql = {
             (if std.length(groupRight) > 0 then ' group_right (%s)' % std.join(', ', groupRight) else ' group_right()')
           else ''
         );
-      '%s %s%s%s %s' % [params.left, op, if bool == true then ' bool' else '', matching, params.right],
+      '(%s %s%s%s %s)' % [params.left, op, if bool == true then ' bool' else '', matching, params.right],
 
   add(params):: self.binaryOp('+', params),
   sub(params):: self.binaryOp('-', params),

--- a/spec/fixtures/conformance.json
+++ b/spec/fixtures/conformance.json
@@ -308,7 +308,7 @@
         "left": "metric_a",
         "right": "metric_b"
       },
-      "expected": "metric_a + metric_b"
+      "expected": "(metric_a + metric_b)"
     },
     {
       "suite": "arithmeticBinaryOp",
@@ -317,7 +317,7 @@
         "left": "metric_a",
         "right": "metric_b"
       },
-      "expected": "metric_a - metric_b"
+      "expected": "(metric_a - metric_b)"
     },
     {
       "suite": "arithmeticBinaryOp",
@@ -326,7 +326,7 @@
         "left": "metric_a",
         "right": "metric_b"
       },
-      "expected": "metric_a * metric_b"
+      "expected": "(metric_a * metric_b)"
     },
     {
       "suite": "arithmeticBinaryOp",
@@ -335,7 +335,7 @@
         "left": "metric_a",
         "right": "metric_b"
       },
-      "expected": "metric_a / metric_b"
+      "expected": "(metric_a / metric_b)"
     },
     {
       "suite": "arithmeticBinaryOp",
@@ -344,7 +344,7 @@
         "left": "metric_a",
         "right": "metric_b"
       },
-      "expected": "metric_a % metric_b"
+      "expected": "(metric_a % metric_b)"
     },
     {
       "suite": "arithmeticBinaryOp",
@@ -353,7 +353,7 @@
         "left": "metric_a",
         "right": "metric_b"
       },
-      "expected": "metric_a ^ metric_b"
+      "expected": "(metric_a ^ metric_b)"
     },
     {
       "suite": "arithmeticBinaryOp",
@@ -365,7 +365,7 @@
           "instance"
         ]
       },
-      "expected": "metric_a / on (instance) metric_b"
+      "expected": "(metric_a / on (instance) metric_b)"
     },
     {
       "suite": "arithmeticBinaryOp",
@@ -378,7 +378,7 @@
           "job"
         ]
       },
-      "expected": "metric_a * on (instance, job) metric_b"
+      "expected": "(metric_a * on (instance, job) metric_b)"
     },
     {
       "suite": "arithmeticBinaryOp",
@@ -390,7 +390,7 @@
           "job"
         ]
       },
-      "expected": "metric_a / ignoring (job) metric_b"
+      "expected": "(metric_a / ignoring (job) metric_b)"
     },
     {
       "suite": "arithmeticBinaryOp",
@@ -403,7 +403,7 @@
           "env"
         ]
       },
-      "expected": "metric_a - ignoring (job, env) metric_b"
+      "expected": "(metric_a - ignoring (job, env) metric_b)"
     },
     {
       "suite": "arithmeticBinaryOp",
@@ -418,7 +418,7 @@
           "job"
         ]
       },
-      "expected": "metric_a / on (instance) metric_b"
+      "expected": "(metric_a / on (instance) metric_b)"
     },
     {
       "suite": "arithmeticBinaryOp",
@@ -431,7 +431,7 @@
         ],
         "groupLeft": []
       },
-      "expected": "metric_a / on (instance) group_left() metric_b"
+      "expected": "(metric_a / on (instance) group_left() metric_b)"
     },
     {
       "suite": "arithmeticBinaryOp",
@@ -446,7 +446,7 @@
           "job"
         ]
       },
-      "expected": "metric_a / on (instance) group_left (job) metric_b"
+      "expected": "(metric_a / on (instance) group_left (job) metric_b)"
     },
     {
       "suite": "arithmeticBinaryOp",
@@ -462,7 +462,7 @@
           "env"
         ]
       },
-      "expected": "metric_a * on (instance) group_left (job, env) metric_b"
+      "expected": "(metric_a * on (instance) group_left (job, env) metric_b)"
     },
     {
       "suite": "arithmeticBinaryOp",
@@ -476,7 +476,7 @@
         ],
         "groupLeft": []
       },
-      "expected": "kube_pod_info * on (pod, namespace) group_left() (k8s_pod_phase{phase=\"Running\"} <= bool 2)"
+      "expected": "(kube_pod_info * on (pod, namespace) group_left() (k8s_pod_phase{phase=\"Running\"} <= bool 2))"
     },
     {
       "suite": "arithmeticBinaryOp",
@@ -489,7 +489,7 @@
         ],
         "groupRight": []
       },
-      "expected": "metric_a / on (instance) group_right() metric_b"
+      "expected": "(metric_a / on (instance) group_right() metric_b)"
     },
     {
       "suite": "arithmeticBinaryOp",
@@ -503,7 +503,7 @@
         ],
         "groupRight": []
       },
-      "expected": "kube_pod_info * on (pod, namespace) group_right() (k8s_pod_phase{phase=\"Running\"} <= bool 2)"
+      "expected": "(kube_pod_info * on (pod, namespace) group_right() (k8s_pod_phase{phase=\"Running\"} <= bool 2))"
     },
     {
       "suite": "arithmeticBinaryOp",
@@ -518,7 +518,7 @@
           "env"
         ]
       },
-      "expected": "metric_a + ignoring (job) group_right (env) metric_b"
+      "expected": "(metric_a + ignoring (job) group_right (env) metric_b)"
     },
     {
       "suite": "arithmeticBinaryOp",
@@ -536,7 +536,7 @@
           "env"
         ]
       },
-      "expected": "metric_a / on (instance) group_left (job) metric_b"
+      "expected": "(metric_a / on (instance) group_left (job) metric_b)"
     },
     {
       "suite": "arithmeticBinaryOp",
@@ -565,7 +565,7 @@
         ],
         "groupLeft": []
       },
-      "expected": "rate(http_requests_total{code=\"200\"}[$__rate_interval]) / on (instance) group_left() rate(http_requests_total[$__rate_interval])"
+      "expected": "(rate(http_requests_total{code=\"200\"}[$__rate_interval]) / on (instance) group_left() rate(http_requests_total[$__rate_interval]))"
     },
     {
       "suite": "arithmeticBinaryOp",
@@ -590,13 +590,337 @@
       "error": "group_left/group_right require an \"on\" or \"ignoring\" clause"
     },
     {
+      "suite": "binaryOpPrecedence",
+      "fn": "mul",
+      "params": {
+        "left": "a",
+        "right": "b"
+      },
+      "expected": "(a * b)"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "pow",
+      "params": {
+        "left": "(a * b)",
+        "right": "c"
+      },
+      "expected": "((a * b) ^ c)"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "mul",
+      "params": {
+        "left": "b",
+        "right": "c"
+      },
+      "expected": "(b * c)"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "pow",
+      "params": {
+        "left": "a",
+        "right": "(b * c)"
+      },
+      "expected": "(a ^ (b * c))"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "add",
+      "params": {
+        "left": "a",
+        "right": "b"
+      },
+      "expected": "(a + b)"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "mul",
+      "params": {
+        "left": "(a + b)",
+        "right": "c"
+      },
+      "expected": "((a + b) * c)"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "add",
+      "params": {
+        "left": "b",
+        "right": "c"
+      },
+      "expected": "(b + c)"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "mul",
+      "params": {
+        "left": "a",
+        "right": "(b + c)"
+      },
+      "expected": "(a * (b + c))"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "eq",
+      "params": {
+        "left": "a",
+        "right": "b"
+      },
+      "expected": "(a == b)"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "add",
+      "params": {
+        "left": "(a == b)",
+        "right": "c"
+      },
+      "expected": "((a == b) + c)"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "eq",
+      "params": {
+        "left": "b",
+        "right": "c"
+      },
+      "expected": "(b == c)"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "add",
+      "params": {
+        "left": "a",
+        "right": "(b == c)"
+      },
+      "expected": "(a + (b == c))"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "and",
+      "params": {
+        "left": "a",
+        "right": "b"
+      },
+      "expected": "(a and b)"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "eq",
+      "params": {
+        "left": "(a and b)",
+        "right": "c"
+      },
+      "expected": "((a and b) == c)"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "and",
+      "params": {
+        "left": "b",
+        "right": "c"
+      },
+      "expected": "(b and c)"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "eq",
+      "params": {
+        "left": "a",
+        "right": "(b and c)"
+      },
+      "expected": "(a == (b and c))"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "or",
+      "params": {
+        "left": "a",
+        "right": "b"
+      },
+      "expected": "(a or b)"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "and",
+      "params": {
+        "left": "(a or b)",
+        "right": "c"
+      },
+      "expected": "((a or b) and c)"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "or",
+      "params": {
+        "left": "b",
+        "right": "c"
+      },
+      "expected": "(b or c)"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "and",
+      "params": {
+        "left": "a",
+        "right": "(b or c)"
+      },
+      "expected": "(a and (b or c))"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "add",
+      "params": {
+        "left": "(a * b)",
+        "right": "c"
+      },
+      "expected": "((a * b) + c)"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "add",
+      "params": {
+        "left": "a",
+        "right": "(b * c)"
+      },
+      "expected": "(a + (b * c))"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "sub",
+      "params": {
+        "left": "b",
+        "right": "c"
+      },
+      "expected": "(b - c)"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "sub",
+      "params": {
+        "left": "a",
+        "right": "(b - c)"
+      },
+      "expected": "(a - (b - c))"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "div",
+      "params": {
+        "left": "a",
+        "right": "(b * c)"
+      },
+      "expected": "(a / (b * c))"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "unless",
+      "params": {
+        "left": "b",
+        "right": "c"
+      },
+      "expected": "(b unless c)"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "and",
+      "params": {
+        "left": "a",
+        "right": "(b unless c)"
+      },
+      "expected": "(a and (b unless c))"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "neq",
+      "params": {
+        "left": "b",
+        "right": "c"
+      },
+      "expected": "(b != c)"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "eq",
+      "params": {
+        "left": "a",
+        "right": "(b != c)"
+      },
+      "expected": "(a == (b != c))"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "pow",
+      "params": {
+        "left": "a",
+        "right": "b"
+      },
+      "expected": "(a ^ b)"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "pow",
+      "params": {
+        "left": "(a ^ b)",
+        "right": "c"
+      },
+      "expected": "((a ^ b) ^ c)"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "sub",
+      "params": {
+        "left": "a",
+        "right": "b"
+      },
+      "expected": "(a - b)"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "sub",
+      "params": {
+        "left": "(a - b)",
+        "right": "c"
+      },
+      "expected": "((a - b) - c)"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "pow",
+      "params": {
+        "left": "b",
+        "right": "c"
+      },
+      "expected": "(b ^ c)"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "pow",
+      "params": {
+        "left": "a",
+        "right": "(b ^ c)"
+      },
+      "expected": "(a ^ (b ^ c))"
+    },
+    {
+      "suite": "binaryOpPrecedence",
+      "fn": "neq",
+      "params": {
+        "left": "(a == b)",
+        "right": "c"
+      },
+      "expected": "((a == b) != c)"
+    },
+    {
       "suite": "comparisonBinaryOp",
       "fn": "eq",
       "params": {
         "left": "metric_a",
         "right": "metric_b"
       },
-      "expected": "metric_a == metric_b"
+      "expected": "(metric_a == metric_b)"
     },
     {
       "suite": "comparisonBinaryOp",
@@ -605,7 +929,7 @@
         "left": "metric_a",
         "right": "metric_b"
       },
-      "expected": "metric_a != metric_b"
+      "expected": "(metric_a != metric_b)"
     },
     {
       "suite": "comparisonBinaryOp",
@@ -614,7 +938,7 @@
         "left": "metric_a",
         "right": "metric_b"
       },
-      "expected": "metric_a > metric_b"
+      "expected": "(metric_a > metric_b)"
     },
     {
       "suite": "comparisonBinaryOp",
@@ -623,7 +947,7 @@
         "left": "metric_a",
         "right": "metric_b"
       },
-      "expected": "metric_a < metric_b"
+      "expected": "(metric_a < metric_b)"
     },
     {
       "suite": "comparisonBinaryOp",
@@ -632,7 +956,7 @@
         "left": "metric_a",
         "right": "metric_b"
       },
-      "expected": "metric_a >= metric_b"
+      "expected": "(metric_a >= metric_b)"
     },
     {
       "suite": "comparisonBinaryOp",
@@ -641,7 +965,7 @@
         "left": "metric_a",
         "right": "metric_b"
       },
-      "expected": "metric_a <= metric_b"
+      "expected": "(metric_a <= metric_b)"
     },
     {
       "suite": "comparisonBinaryOp",
@@ -651,7 +975,7 @@
         "right": "1",
         "bool": true
       },
-      "expected": "metric_a == bool 1"
+      "expected": "(metric_a == bool 1)"
     },
     {
       "suite": "comparisonBinaryOp",
@@ -661,7 +985,7 @@
         "right": "0",
         "bool": true
       },
-      "expected": "metric_a != bool 0"
+      "expected": "(metric_a != bool 0)"
     },
     {
       "suite": "comparisonBinaryOp",
@@ -671,7 +995,7 @@
         "right": "0",
         "bool": true
       },
-      "expected": "metric_a > bool 0"
+      "expected": "(metric_a > bool 0)"
     },
     {
       "suite": "comparisonBinaryOp",
@@ -681,7 +1005,7 @@
         "right": "0",
         "bool": true
       },
-      "expected": "metric_a < bool 0"
+      "expected": "(metric_a < bool 0)"
     },
     {
       "suite": "comparisonBinaryOp",
@@ -691,7 +1015,7 @@
         "right": "1",
         "bool": true
       },
-      "expected": "metric_a >= bool 1"
+      "expected": "(metric_a >= bool 1)"
     },
     {
       "suite": "comparisonBinaryOp",
@@ -701,7 +1025,7 @@
         "right": "2",
         "bool": true
       },
-      "expected": "metric_a <= bool 2"
+      "expected": "(metric_a <= bool 2)"
     },
     {
       "suite": "comparisonBinaryOp",
@@ -711,7 +1035,7 @@
         "right": "0",
         "bool": false
       },
-      "expected": "metric_a > 0"
+      "expected": "(metric_a > 0)"
     },
     {
       "suite": "comparisonBinaryOp",
@@ -723,7 +1047,7 @@
           "instance"
         ]
       },
-      "expected": "metric_a > on (instance) metric_b"
+      "expected": "(metric_a > on (instance) metric_b)"
     },
     {
       "suite": "comparisonBinaryOp",
@@ -736,7 +1060,7 @@
           "job"
         ]
       },
-      "expected": "metric_a < on (instance, job) metric_b"
+      "expected": "(metric_a < on (instance, job) metric_b)"
     },
     {
       "suite": "comparisonBinaryOp",
@@ -748,7 +1072,7 @@
           "job"
         ]
       },
-      "expected": "metric_a >= ignoring (job) metric_b"
+      "expected": "(metric_a >= ignoring (job) metric_b)"
     },
     {
       "suite": "comparisonBinaryOp",
@@ -761,7 +1085,7 @@
           "env"
         ]
       },
-      "expected": "metric_a <= ignoring (job, env) metric_b"
+      "expected": "(metric_a <= ignoring (job, env) metric_b)"
     },
     {
       "suite": "comparisonBinaryOp",
@@ -776,7 +1100,7 @@
           "job"
         ]
       },
-      "expected": "metric_a == on (instance) metric_b"
+      "expected": "(metric_a == on (instance) metric_b)"
     },
     {
       "suite": "comparisonBinaryOp",
@@ -789,7 +1113,7 @@
           "instance"
         ]
       },
-      "expected": "metric_a == bool on (instance) metric_b"
+      "expected": "(metric_a == bool on (instance) metric_b)"
     },
     {
       "suite": "comparisonBinaryOp",
@@ -803,7 +1127,7 @@
           "env"
         ]
       },
-      "expected": "metric_a >= bool ignoring (job, env) metric_b"
+      "expected": "(metric_a >= bool ignoring (job, env) metric_b)"
     },
     {
       "suite": "comparisonBinaryOp",
@@ -816,7 +1140,7 @@
         ],
         "groupLeft": []
       },
-      "expected": "metric_a > on (instance) group_left() metric_b"
+      "expected": "(metric_a > on (instance) group_left() metric_b)"
     },
     {
       "suite": "comparisonBinaryOp",
@@ -831,7 +1155,7 @@
           "job"
         ]
       },
-      "expected": "metric_a > on (instance) group_left (job) metric_b"
+      "expected": "(metric_a > on (instance) group_left (job) metric_b)"
     },
     {
       "suite": "comparisonBinaryOp",
@@ -847,7 +1171,7 @@
           "env"
         ]
       },
-      "expected": "metric_a < on (instance) group_left (job, env) metric_b"
+      "expected": "(metric_a < on (instance) group_left (job, env) metric_b)"
     },
     {
       "suite": "comparisonBinaryOp",
@@ -861,7 +1185,7 @@
         ],
         "groupLeft": []
       },
-      "expected": "kube_pod_info >= on (pod, namespace) group_left() (k8s_pod_phase{phase=\"Running\"} <= bool 2)"
+      "expected": "(kube_pod_info >= on (pod, namespace) group_left() (k8s_pod_phase{phase=\"Running\"} <= bool 2))"
     },
     {
       "suite": "comparisonBinaryOp",
@@ -874,7 +1198,7 @@
         ],
         "groupRight": []
       },
-      "expected": "metric_a < on (instance) group_right() metric_b"
+      "expected": "(metric_a < on (instance) group_right() metric_b)"
     },
     {
       "suite": "comparisonBinaryOp",
@@ -888,7 +1212,7 @@
         ],
         "groupRight": []
       },
-      "expected": "kube_pod_info <= on (pod, namespace) group_right() (k8s_pod_phase{phase=\"Running\"} <= bool 2)"
+      "expected": "(kube_pod_info <= on (pod, namespace) group_right() (k8s_pod_phase{phase=\"Running\"} <= bool 2))"
     },
     {
       "suite": "comparisonBinaryOp",
@@ -903,7 +1227,7 @@
           "env"
         ]
       },
-      "expected": "metric_a != ignoring (job) group_right (env) metric_b"
+      "expected": "(metric_a != ignoring (job) group_right (env) metric_b)"
     },
     {
       "suite": "comparisonBinaryOp",
@@ -921,7 +1245,7 @@
           "env"
         ]
       },
-      "expected": "metric_a > on (instance) group_left (job) metric_b"
+      "expected": "(metric_a > on (instance) group_left (job) metric_b)"
     },
     {
       "suite": "comparisonBinaryOp",
@@ -1018,7 +1342,7 @@
         "left": "metric_a",
         "right": "metric_b"
       },
-      "expected": "metric_a and metric_b"
+      "expected": "(metric_a and metric_b)"
     },
     {
       "suite": "logicalOp",
@@ -1027,7 +1351,7 @@
         "left": "metric_a",
         "right": "metric_b"
       },
-      "expected": "metric_a or metric_b"
+      "expected": "(metric_a or metric_b)"
     },
     {
       "suite": "logicalOp",
@@ -1036,7 +1360,7 @@
         "left": "metric_a",
         "right": "metric_b"
       },
-      "expected": "metric_a unless metric_b"
+      "expected": "(metric_a unless metric_b)"
     },
     {
       "suite": "logicalOp",
@@ -1049,7 +1373,7 @@
           "namespace"
         ]
       },
-      "expected": "metric_a or on (cluster, namespace) metric_b"
+      "expected": "(metric_a or on (cluster, namespace) metric_b)"
     },
     {
       "suite": "offset",

--- a/src/promql.ts
+++ b/src/promql.ts
@@ -94,7 +94,7 @@ export const promql = {
     } else if (groupRight !== undefined) {
       matching += groupRight.length > 0 ? ` group_right (${groupRight.join(', ')})` : ' group_right()';
     }
-    return `${left} ${op}${bool ? ' bool' : ''}${matching} ${right}`;
+    return `(${left} ${op}${bool ? ' bool' : ''}${matching} ${right})`;
   },
 
   add: (params: ArithmeticBinaryOpParams) => promql.binaryOp('+', params),

--- a/src/test/arithmeticBinaryOp.spec.ts
+++ b/src/test/arithmeticBinaryOp.spec.ts
@@ -7,70 +7,70 @@ describe('Operators: Arithmetic Binary Ops with Vector Matching', () => {
     // Basic operators
     {
       actual: () => promql.add({ left: 'metric_a', right: 'metric_b' }),
-      expected: 'metric_a + metric_b',
+      expected: '(metric_a + metric_b)',
     },
     {
       actual: () => promql.sub({ left: 'metric_a', right: 'metric_b' }),
-      expected: 'metric_a - metric_b',
+      expected: '(metric_a - metric_b)',
     },
     {
       actual: () => promql.mul({ left: 'metric_a', right: 'metric_b' }),
-      expected: 'metric_a * metric_b',
+      expected: '(metric_a * metric_b)',
     },
     {
       actual: () => promql.div({ left: 'metric_a', right: 'metric_b' }),
-      expected: 'metric_a / metric_b',
+      expected: '(metric_a / metric_b)',
     },
     {
       actual: () => promql.mod({ left: 'metric_a', right: 'metric_b' }),
-      expected: 'metric_a % metric_b',
+      expected: '(metric_a % metric_b)',
     },
     {
       actual: () => promql.pow({ left: 'metric_a', right: 'metric_b' }),
-      expected: 'metric_a ^ metric_b',
+      expected: '(metric_a ^ metric_b)',
     },
 
     // on matching
     {
       actual: () => promql.div({ left: 'metric_a', right: 'metric_b', on: ['instance'] }),
-      expected: 'metric_a / on (instance) metric_b',
+      expected: '(metric_a / on (instance) metric_b)',
     },
     {
       actual: () => promql.mul({ left: 'metric_a', right: 'metric_b', on: ['instance', 'job'] }),
-      expected: 'metric_a * on (instance, job) metric_b',
+      expected: '(metric_a * on (instance, job) metric_b)',
     },
 
     // ignoring matching
     {
       actual: () => promql.div({ left: 'metric_a', right: 'metric_b', ignoring: ['job'] }),
-      expected: 'metric_a / ignoring (job) metric_b',
+      expected: '(metric_a / ignoring (job) metric_b)',
     },
     {
       actual: () => promql.sub({ left: 'metric_a', right: 'metric_b', ignoring: ['job', 'env'] }),
-      expected: 'metric_a - ignoring (job, env) metric_b',
+      expected: '(metric_a - ignoring (job, env) metric_b)',
     },
 
     // on wins over ignoring when both provided
     {
       actual: () => promql.div({ left: 'metric_a', right: 'metric_b', on: ['instance'], ignoring: ['job'] }),
-      expected: 'metric_a / on (instance) metric_b',
+      expected: '(metric_a / on (instance) metric_b)',
     },
 
     // group_left without labels
     {
       actual: () => promql.div({ left: 'metric_a', right: 'metric_b', on: ['instance'], groupLeft: [] }),
-      expected: 'metric_a / on (instance) group_left() metric_b',
+      expected: '(metric_a / on (instance) group_left() metric_b)',
     },
 
     // group_left with labels
     {
       actual: () => promql.div({ left: 'metric_a', right: 'metric_b', on: ['instance'], groupLeft: ['job'] }),
-      expected: 'metric_a / on (instance) group_left (job) metric_b',
+      expected: '(metric_a / on (instance) group_left (job) metric_b)',
     },
     {
       actual: () =>
         promql.mul({ left: 'metric_a', right: 'metric_b', on: ['instance'], groupLeft: ['job', 'env'] }),
-      expected: 'metric_a * on (instance) group_left (job, env) metric_b',
+      expected: '(metric_a * on (instance) group_left (job, env) metric_b)',
     },
 
     // group_left() with right-hand side starting with ( — regression: bare group_left would cause PromQL parser ambiguity
@@ -82,13 +82,13 @@ describe('Operators: Arithmetic Binary Ops with Vector Matching', () => {
           on: ['pod', 'namespace'],
           groupLeft: [],
         }),
-      expected: 'kube_pod_info * on (pod, namespace) group_left() (k8s_pod_phase{phase="Running"} <= bool 2)',
+      expected: '(kube_pod_info * on (pod, namespace) group_left() (k8s_pod_phase{phase="Running"} <= bool 2))',
     },
 
     // group_right without labels
     {
       actual: () => promql.div({ left: 'metric_a', right: 'metric_b', on: ['instance'], groupRight: [] }),
-      expected: 'metric_a / on (instance) group_right() metric_b',
+      expected: '(metric_a / on (instance) group_right() metric_b)',
     },
 
     // group_right() with right-hand side starting with ( — regression: bare group_right would cause PromQL parser ambiguity
@@ -100,20 +100,20 @@ describe('Operators: Arithmetic Binary Ops with Vector Matching', () => {
           on: ['pod', 'namespace'],
           groupRight: [],
         }),
-      expected: 'kube_pod_info * on (pod, namespace) group_right() (k8s_pod_phase{phase="Running"} <= bool 2)',
+      expected: '(kube_pod_info * on (pod, namespace) group_right() (k8s_pod_phase{phase="Running"} <= bool 2))',
     },
 
     // group_right with labels
     {
       actual: () => promql.add({ left: 'metric_a', right: 'metric_b', ignoring: ['job'], groupRight: ['env'] }),
-      expected: 'metric_a + ignoring (job) group_right (env) metric_b',
+      expected: '(metric_a + ignoring (job) group_right (env) metric_b)',
     },
 
     // groupLeft wins over groupRight when both provided
     {
       actual: () =>
         promql.div({ left: 'metric_a', right: 'metric_b', on: ['instance'], groupLeft: ['job'], groupRight: ['env'] }),
-      expected: 'metric_a / on (instance) group_left (job) metric_b',
+      expected: '(metric_a / on (instance) group_left (job) metric_b)',
     },
 
     // Composable with other promql functions
@@ -126,7 +126,7 @@ describe('Operators: Arithmetic Binary Ops with Vector Matching', () => {
           groupLeft: [],
         }),
       expected:
-        'rate(http_requests_total{code="200"}[$__rate_interval]) / on (instance) group_left() rate(http_requests_total[$__rate_interval])',
+        '(rate(http_requests_total{code="200"}[$__rate_interval]) / on (instance) group_left() rate(http_requests_total[$__rate_interval]))',
     },
   ])('Generate PromQL query: $expected', ({ actual, expected }) => {
     expect(actual()).toStrictEqual(expected);

--- a/src/test/binaryOpPrecedence.spec.ts
+++ b/src/test/binaryOpPrecedence.spec.ts
@@ -5,51 +5,51 @@ describe('Operators: Binary Op Precedence', () => {
   it.each([
     {
       actual: () => promql.pow({ left: promql.mul({ left: 'a', right: 'b' }), right: 'c' }),
-      expected: '(a * b) ^ c',
+      expected: '((a * b) ^ c)',
     },
     {
       actual: () => promql.pow({ left: 'a', right: promql.mul({ left: 'b', right: 'c' }) }),
-      expected: 'a ^ (b * c)',
+      expected: '(a ^ (b * c))',
     },
     {
       actual: () => promql.mul({ left: promql.add({ left: 'a', right: 'b' }), right: 'c' }),
-      expected: '(a + b) * c',
+      expected: '((a + b) * c)',
     },
     {
       actual: () => promql.mul({ left: 'a', right: promql.add({ left: 'b', right: 'c' }) }),
-      expected: 'a * (b + c)',
+      expected: '(a * (b + c))',
     },
     {
       actual: () => promql.add({ left: promql.eq({ left: 'a', right: 'b' }), right: 'c' }),
-      expected: '(a == b) + c',
+      expected: '((a == b) + c)',
     },
     {
       actual: () => promql.add({ left: 'a', right: promql.eq({ left: 'b', right: 'c' }) }),
-      expected: 'a + (b == c)',
+      expected: '(a + (b == c))',
     },
     {
       actual: () => promql.eq({ left: promql.and({ left: 'a', right: 'b' }), right: 'c' }),
-      expected: '(a and b) == c',
+      expected: '((a and b) == c)',
     },
     {
       actual: () => promql.eq({ left: 'a', right: promql.and({ left: 'b', right: 'c' }) }),
-      expected: 'a == (b and c)',
+      expected: '(a == (b and c))',
     },
     {
       actual: () => promql.and({ left: promql.or({ left: 'a', right: 'b' }), right: 'c' }),
-      expected: '(a or b) and c',
+      expected: '((a or b) and c)',
     },
     {
       actual: () => promql.and({ left: 'a', right: promql.or({ left: 'b', right: 'c' }) }),
-      expected: 'a and (b or c)',
+      expected: '(a and (b or c))',
     },
     {
       actual: () => promql.add({ left: promql.mul({ left: 'a', right: 'b' }), right: 'c' }),
-      expected: 'a * b + c',
+      expected: '((a * b) + c)',
     },
     {
       actual: () => promql.add({ left: 'a', right: promql.mul({ left: 'b', right: 'c' }) }),
-      expected: 'a + b * c',
+      expected: '(a + (b * c))',
     },
   ])('preserves precedence: $expected', ({ actual, expected }) => {
     expect(actual()).toStrictEqual(expected);
@@ -58,35 +58,35 @@ describe('Operators: Binary Op Precedence', () => {
   it.each([
     {
       actual: () => promql.sub({ left: 'a', right: promql.sub({ left: 'b', right: 'c' }) }),
-      expected: 'a - (b - c)',
+      expected: '(a - (b - c))',
     },
     {
       actual: () => promql.div({ left: 'a', right: promql.mul({ left: 'b', right: 'c' }) }),
-      expected: 'a / (b * c)',
+      expected: '(a / (b * c))',
     },
     {
       actual: () => promql.and({ left: 'a', right: promql.unless({ left: 'b', right: 'c' }) }),
-      expected: 'a and (b unless c)',
+      expected: '(a and (b unless c))',
     },
     {
       actual: () => promql.eq({ left: 'a', right: promql.neq({ left: 'b', right: 'c' }) }),
-      expected: 'a == (b != c)',
+      expected: '(a == (b != c))',
     },
     {
       actual: () => promql.pow({ left: promql.pow({ left: 'a', right: 'b' }), right: 'c' }),
-      expected: '(a ^ b) ^ c',
+      expected: '((a ^ b) ^ c)',
     },
     {
       actual: () => promql.sub({ left: promql.sub({ left: 'a', right: 'b' }), right: 'c' }),
-      expected: 'a - b - c',
+      expected: '((a - b) - c)',
     },
     {
       actual: () => promql.pow({ left: 'a', right: promql.pow({ left: 'b', right: 'c' }) }),
-      expected: 'a ^ b ^ c',
+      expected: '(a ^ (b ^ c))',
     },
     {
       actual: () => promql.neq({ left: promql.eq({ left: 'a', right: 'b' }), right: 'c' }),
-      expected: 'a == b != c',
+      expected: '((a == b) != c)',
     },
   ])('preserves associativity: $expected', ({ actual, expected }) => {
     expect(actual()).toStrictEqual(expected);

--- a/src/test/binaryOpPrecedence.spec.ts
+++ b/src/test/binaryOpPrecedence.spec.ts
@@ -1,0 +1,94 @@
+import { promql } from '../promql';
+
+// https://prometheus.io/docs/prometheus/latest/querying/operators/#binary-operator-precedence
+describe('Operators: Binary Op Precedence', () => {
+  it.each([
+    {
+      actual: () => promql.pow({ left: promql.mul({ left: 'a', right: 'b' }), right: 'c' }),
+      expected: '(a * b) ^ c',
+    },
+    {
+      actual: () => promql.pow({ left: 'a', right: promql.mul({ left: 'b', right: 'c' }) }),
+      expected: 'a ^ (b * c)',
+    },
+    {
+      actual: () => promql.mul({ left: promql.add({ left: 'a', right: 'b' }), right: 'c' }),
+      expected: '(a + b) * c',
+    },
+    {
+      actual: () => promql.mul({ left: 'a', right: promql.add({ left: 'b', right: 'c' }) }),
+      expected: 'a * (b + c)',
+    },
+    {
+      actual: () => promql.add({ left: promql.eq({ left: 'a', right: 'b' }), right: 'c' }),
+      expected: '(a == b) + c',
+    },
+    {
+      actual: () => promql.add({ left: 'a', right: promql.eq({ left: 'b', right: 'c' }) }),
+      expected: 'a + (b == c)',
+    },
+    {
+      actual: () => promql.eq({ left: promql.and({ left: 'a', right: 'b' }), right: 'c' }),
+      expected: '(a and b) == c',
+    },
+    {
+      actual: () => promql.eq({ left: 'a', right: promql.and({ left: 'b', right: 'c' }) }),
+      expected: 'a == (b and c)',
+    },
+    {
+      actual: () => promql.and({ left: promql.or({ left: 'a', right: 'b' }), right: 'c' }),
+      expected: '(a or b) and c',
+    },
+    {
+      actual: () => promql.and({ left: 'a', right: promql.or({ left: 'b', right: 'c' }) }),
+      expected: 'a and (b or c)',
+    },
+    {
+      actual: () => promql.add({ left: promql.mul({ left: 'a', right: 'b' }), right: 'c' }),
+      expected: 'a * b + c',
+    },
+    {
+      actual: () => promql.add({ left: 'a', right: promql.mul({ left: 'b', right: 'c' }) }),
+      expected: 'a + b * c',
+    },
+  ])('preserves precedence: $expected', ({ actual, expected }) => {
+    expect(actual()).toStrictEqual(expected);
+  });
+
+  it.each([
+    {
+      actual: () => promql.sub({ left: 'a', right: promql.sub({ left: 'b', right: 'c' }) }),
+      expected: 'a - (b - c)',
+    },
+    {
+      actual: () => promql.div({ left: 'a', right: promql.mul({ left: 'b', right: 'c' }) }),
+      expected: 'a / (b * c)',
+    },
+    {
+      actual: () => promql.and({ left: 'a', right: promql.unless({ left: 'b', right: 'c' }) }),
+      expected: 'a and (b unless c)',
+    },
+    {
+      actual: () => promql.eq({ left: 'a', right: promql.neq({ left: 'b', right: 'c' }) }),
+      expected: 'a == (b != c)',
+    },
+    {
+      actual: () => promql.pow({ left: promql.pow({ left: 'a', right: 'b' }), right: 'c' }),
+      expected: '(a ^ b) ^ c',
+    },
+    {
+      actual: () => promql.sub({ left: promql.sub({ left: 'a', right: 'b' }), right: 'c' }),
+      expected: 'a - b - c',
+    },
+    {
+      actual: () => promql.pow({ left: 'a', right: promql.pow({ left: 'b', right: 'c' }) }),
+      expected: 'a ^ b ^ c',
+    },
+    {
+      actual: () => promql.neq({ left: promql.eq({ left: 'a', right: 'b' }), right: 'c' }),
+      expected: 'a == b != c',
+    },
+  ])('preserves associativity: $expected', ({ actual, expected }) => {
+    expect(actual()).toStrictEqual(expected);
+  });
+});

--- a/src/test/comparisonBinaryOp.spec.ts
+++ b/src/test/comparisonBinaryOp.spec.ts
@@ -11,110 +11,110 @@ describe('Operators: Comparison Binary Ops', () => {
     // Basic operators
     {
       actual: () => promql.eq({ left: 'metric_a', right: 'metric_b' }),
-      expected: 'metric_a == metric_b',
+      expected: '(metric_a == metric_b)',
     },
     {
       actual: () => promql.neq({ left: 'metric_a', right: 'metric_b' }),
-      expected: 'metric_a != metric_b',
+      expected: '(metric_a != metric_b)',
     },
     {
       actual: () => promql.gt({ left: 'metric_a', right: 'metric_b' }),
-      expected: 'metric_a > metric_b',
+      expected: '(metric_a > metric_b)',
     },
     {
       actual: () => promql.lt({ left: 'metric_a', right: 'metric_b' }),
-      expected: 'metric_a < metric_b',
+      expected: '(metric_a < metric_b)',
     },
     {
       actual: () => promql.gte({ left: 'metric_a', right: 'metric_b' }),
-      expected: 'metric_a >= metric_b',
+      expected: '(metric_a >= metric_b)',
     },
     {
       actual: () => promql.lte({ left: 'metric_a', right: 'metric_b' }),
-      expected: 'metric_a <= metric_b',
+      expected: '(metric_a <= metric_b)',
     },
 
     // bool modifier
     {
       actual: () => promql.eq({ left: 'metric_a', right: '1', bool: true }),
-      expected: 'metric_a == bool 1',
+      expected: '(metric_a == bool 1)',
     },
     {
       actual: () => promql.neq({ left: 'metric_a', right: '0', bool: true }),
-      expected: 'metric_a != bool 0',
+      expected: '(metric_a != bool 0)',
     },
     {
       actual: () => promql.gt({ left: 'metric_a', right: '0', bool: true }),
-      expected: 'metric_a > bool 0',
+      expected: '(metric_a > bool 0)',
     },
     {
       actual: () => promql.lt({ left: 'metric_a', right: '0', bool: true }),
-      expected: 'metric_a < bool 0',
+      expected: '(metric_a < bool 0)',
     },
     {
       actual: () => promql.gte({ left: 'metric_a', right: '1', bool: true }),
-      expected: 'metric_a >= bool 1',
+      expected: '(metric_a >= bool 1)',
     },
     {
       actual: () => promql.lte({ left: 'metric_a', right: '2', bool: true }),
-      expected: 'metric_a <= bool 2',
+      expected: '(metric_a <= bool 2)',
     },
     // bool: false must not emit the modifier
     {
       actual: () => promql.gt({ left: 'metric_a', right: '0', bool: false }),
-      expected: 'metric_a > 0',
+      expected: '(metric_a > 0)',
     },
 
     // on matching
     {
       actual: () => promql.gt({ left: 'metric_a', right: 'metric_b', on: ['instance'] }),
-      expected: 'metric_a > on (instance) metric_b',
+      expected: '(metric_a > on (instance) metric_b)',
     },
     {
       actual: () => promql.lt({ left: 'metric_a', right: 'metric_b', on: ['instance', 'job'] }),
-      expected: 'metric_a < on (instance, job) metric_b',
+      expected: '(metric_a < on (instance, job) metric_b)',
     },
 
     // ignoring matching
     {
       actual: () => promql.gte({ left: 'metric_a', right: 'metric_b', ignoring: ['job'] }),
-      expected: 'metric_a >= ignoring (job) metric_b',
+      expected: '(metric_a >= ignoring (job) metric_b)',
     },
     {
       actual: () => promql.lte({ left: 'metric_a', right: 'metric_b', ignoring: ['job', 'env'] }),
-      expected: 'metric_a <= ignoring (job, env) metric_b',
+      expected: '(metric_a <= ignoring (job, env) metric_b)',
     },
 
     // on wins over ignoring when both provided
     {
       actual: () => promql.eq({ left: 'metric_a', right: 'metric_b', on: ['instance'], ignoring: ['job'] }),
-      expected: 'metric_a == on (instance) metric_b',
+      expected: '(metric_a == on (instance) metric_b)',
     },
 
     // bool sits between the operator and the matching clause
     {
       actual: () => promql.eq({ left: 'metric_a', right: 'metric_b', bool: true, on: ['instance'] }),
-      expected: 'metric_a == bool on (instance) metric_b',
+      expected: '(metric_a == bool on (instance) metric_b)',
     },
     {
       actual: () => promql.gte({ left: 'metric_a', right: 'metric_b', bool: true, ignoring: ['job', 'env'] }),
-      expected: 'metric_a >= bool ignoring (job, env) metric_b',
+      expected: '(metric_a >= bool ignoring (job, env) metric_b)',
     },
 
     // group_left without labels
     {
       actual: () => promql.gt({ left: 'metric_a', right: 'metric_b', on: ['instance'], groupLeft: [] }),
-      expected: 'metric_a > on (instance) group_left() metric_b',
+      expected: '(metric_a > on (instance) group_left() metric_b)',
     },
 
     // group_left with labels
     {
       actual: () => promql.gt({ left: 'metric_a', right: 'metric_b', on: ['instance'], groupLeft: ['job'] }),
-      expected: 'metric_a > on (instance) group_left (job) metric_b',
+      expected: '(metric_a > on (instance) group_left (job) metric_b)',
     },
     {
       actual: () => promql.lt({ left: 'metric_a', right: 'metric_b', on: ['instance'], groupLeft: ['job', 'env'] }),
-      expected: 'metric_a < on (instance) group_left (job, env) metric_b',
+      expected: '(metric_a < on (instance) group_left (job, env) metric_b)',
     },
 
     // group_left() with right-hand side starting with ( — regression: bare group_left would cause PromQL parser ambiguity
@@ -126,13 +126,13 @@ describe('Operators: Comparison Binary Ops', () => {
           on: ['pod', 'namespace'],
           groupLeft: [],
         }),
-      expected: 'kube_pod_info >= on (pod, namespace) group_left() (k8s_pod_phase{phase="Running"} <= bool 2)',
+      expected: '(kube_pod_info >= on (pod, namespace) group_left() (k8s_pod_phase{phase="Running"} <= bool 2))',
     },
 
     // group_right without labels
     {
       actual: () => promql.lt({ left: 'metric_a', right: 'metric_b', on: ['instance'], groupRight: [] }),
-      expected: 'metric_a < on (instance) group_right() metric_b',
+      expected: '(metric_a < on (instance) group_right() metric_b)',
     },
 
     // group_right() with right-hand side starting with ( — regression: bare group_right would cause PromQL parser ambiguity
@@ -144,20 +144,20 @@ describe('Operators: Comparison Binary Ops', () => {
           on: ['pod', 'namespace'],
           groupRight: [],
         }),
-      expected: 'kube_pod_info <= on (pod, namespace) group_right() (k8s_pod_phase{phase="Running"} <= bool 2)',
+      expected: '(kube_pod_info <= on (pod, namespace) group_right() (k8s_pod_phase{phase="Running"} <= bool 2))',
     },
 
     // group_right with labels
     {
       actual: () => promql.neq({ left: 'metric_a', right: 'metric_b', ignoring: ['job'], groupRight: ['env'] }),
-      expected: 'metric_a != ignoring (job) group_right (env) metric_b',
+      expected: '(metric_a != ignoring (job) group_right (env) metric_b)',
     },
 
     // groupLeft wins over groupRight when both provided
     {
       actual: () =>
         promql.gt({ left: 'metric_a', right: 'metric_b', on: ['instance'], groupLeft: ['job'], groupRight: ['env'] }),
-      expected: 'metric_a > on (instance) group_left (job) metric_b',
+      expected: '(metric_a > on (instance) group_left (job) metric_b)',
     },
   ])('Generate PromQL query: $expected', ({ actual, expected }) => {
     expect(actual()).toStrictEqual(expected);

--- a/src/test/logicalOp.spec.ts
+++ b/src/test/logicalOp.spec.ts
@@ -1,26 +1,26 @@
 import { promql } from '../promql';
 
 // https://prometheus.io/docs/prometheus/latest/querying/operators/#logical-set-binary-operators
-// Vector matching behavior (on/ignoring, precedence, empty arrays, composability) is fully
-// covered in arithmeticBinaryOp.spec.ts since and/or/unless delegate to the same helper.
+// Vector matching behavior (on/ignoring and empty arrays) is covered in arithmeticBinaryOp.spec.ts,
+// while composition is covered in binaryOpPrecedence.spec.ts since and/or/unless delegate to the same helper.
 describe('Operators: Logical Set Binary Ops', () => {
   it.each([
     {
       actual: () => promql.and({ left: 'metric_a', right: 'metric_b' }),
-      expected: 'metric_a and metric_b',
+      expected: '(metric_a and metric_b)',
     },
     {
       actual: () => promql.or({ left: 'metric_a', right: 'metric_b' }),
-      expected: 'metric_a or metric_b',
+      expected: '(metric_a or metric_b)',
     },
     {
       actual: () => promql.unless({ left: 'metric_a', right: 'metric_b' }),
-      expected: 'metric_a unless metric_b',
+      expected: '(metric_a unless metric_b)',
     },
     // Sanity check that vector matching flows through to logical ops
     {
       actual: () => promql.or({ left: 'metric_a', right: 'metric_b', on: ['cluster', 'namespace'] }),
-      expected: 'metric_a or on (cluster, namespace) metric_b',
+      expected: '(metric_a or on (cluster, namespace) metric_b)',
     },
   ])('Generate PromQL query: $expected', ({ actual, expected }) => {
     expect(actual()).toStrictEqual(expected);

--- a/src/test/prettify.spec.ts
+++ b/src/test/prettify.spec.ts
@@ -89,7 +89,7 @@ describe('prettify', () => {
         prettify({
           expr: promql.div({ left: 'http_requests_total', right: 'http_requests_duration_seconds' }),
         }),
-      expected: 'http_requests_total / http_requests_duration_seconds',
+      expected: '(http_requests_total / http_requests_duration_seconds)',
     },
     {
       name: 'preserves the $__rate_interval template variable in a range selector',
@@ -175,8 +175,10 @@ describe('prettify', () => {
           }),
         }),
       expected: [
-        'rate(http_requests_total{code="200"}[$__rate_interval])',
-        '/ rate(http_errors_total{code="500"}[$__rate_interval])',
+        '(',
+        '  rate(http_requests_total{code="200"}[$__rate_interval])',
+        '  / rate(http_errors_total{code="500"}[$__rate_interval])',
+        ')',
       ].join('\n'),
     },
     {
@@ -191,7 +193,12 @@ describe('prettify', () => {
           }),
           maxWidth: 40,
         }),
-      expected: ['aaa_total{job="api"}', '/ on (instance) group_left() bbb_total{job="api"}'].join('\n'),
+      expected: [
+        '(',
+        '  aaa_total{job="api"}',
+        '  / on (instance) group_left() bbb_total{job="api"}',
+        ')',
+      ].join('\n'),
     },
     {
       name: 'breaks binary operations inside broken groups with indentation',


### PR DESCRIPTION
Prometheus describes the following precedence for binary operators:

> Binary operator precedence
>
> The following list shows the precedence of binary operators in Prometheus, from highest to lowest.
>
> 1.    ^
> 1.    *, /, %, atan2
> 1.    +, -
> 1.    ==, !=, <=, <, >=, >
> 1.    and, unless
> 1.    or
>
> Operators on the same precedence level are left-associative. For example, 2 * 3 % 2 is equivalent to (2 * 3) % 2. However ^ is right associative, so 2 ^ 3 ^ 2 is equivalent to 2 ^ (3 ^ 2).

See https://prometheus.io/docs/prometheus/3.14/querying/operators/#binary-operator-precedence

With the current implementation we cannot guarantee that operations are handled appropriately. This is especially true for anything involving `or` within another expression. To handle this we add parentheses around all binary operations to ensure that expression wrapping is handled as expected by the caller.
