### PR TITLE
Add support for additional functions (clamp, histogram_...)

### DIFF
--- a/jsonnet/promql.libsonnet
+++ b/jsonnet/promql.libsonnet
@@ -29,7 +29,7 @@
 //      textual representation matters.
 
 local str(v) = if std.type(v) == 'string' then v else std.toString(v);
-local histogramScalar(v) =
+local scalar(v) =
   if std.type(v) != 'number' then v
   else
     local compact = '%.15g' % v;
@@ -179,14 +179,14 @@ local promql = {
   gte(params):: self.binaryOp('>=', params),
   lte(params):: self.binaryOp('<=', params),
 
-  clamp_min(params):: 'clamp_min(%s, %s)' % [params.expr, params.min],
-  clamp_max(params):: 'clamp_max(%s, %s)' % [params.expr, params.max],
-  clamp(params):: 'clamp(%s, %s, %s)' % [params.expr, params.min, params.max],
+  clamp_min(params):: 'clamp_min(%s, %s)' % [params.expr, scalar(params.min)],
+  clamp_max(params):: 'clamp_max(%s, %s)' % [params.expr, scalar(params.max)],
+  clamp(params):: 'clamp(%s, %s, %s)' % [params.expr, scalar(params.min), scalar(params.max)],
 
 
-  histogram_quantile(params):: 'histogram_quantile(%s, %s)' % [histogramScalar(params.quantile), params.expr],
+  histogram_quantile(params):: 'histogram_quantile(%s, %s)' % [scalar(params.quantile), params.expr],
   histogram_fraction(params):: 'histogram_fraction(%s, %s, %s)'
-                               % [histogramScalar(params.lower), histogramScalar(params.upper), params.expr],
+                               % [scalar(params.lower), scalar(params.upper), params.expr],
 
   histogram_avg(params):: 'histogram_avg(%s)' % [params.expr],
   histogram_sum(params):: 'histogram_sum(%s)' % [params.expr],

--- a/jsonnet/promql.libsonnet
+++ b/jsonnet/promql.libsonnet
@@ -169,6 +169,10 @@ local promql = {
   lt(params):: self.binaryOp('<', params),
   gte(params):: self.binaryOp('>=', params),
   lte(params):: self.binaryOp('<=', params),
+
+  clamp_min(params):: 'clamp_min(%s, %s)' % [params.expr, params.min],
+  clamp_max(params):: 'clamp_max(%s, %s)' % [params.expr, params.max],
+  clamp(params):: 'clamp(%s, %s, %s)' % [params.expr, params.min, params.max],
 };
 
 // Composable PromQL metric selector with label matching.

--- a/jsonnet/promql.libsonnet
+++ b/jsonnet/promql.libsonnet
@@ -23,8 +23,17 @@
 //      The TypeScript implementation emits them in object insertion order.
 //      PromQL requires descending order, so callers should already be
 //      passing units this way.
+//   3. Jsonnet may spell numeric histogram arguments differently from
+//      JavaScript (for example around exponent thresholds), while preserving
+//      their numeric value. Pass these arguments as strings when their exact
+//      textual representation matters.
 
 local str(v) = if std.type(v) == 'string' then v else std.toString(v);
+local histogramScalar(v) =
+  if std.type(v) != 'number' then v
+  else
+    local compact = '%.15g' % v;
+    if std.parseJson(compact) == v then compact else std.toString(v);
 
 // PromQL label matching operators (=, !=, =~, !~).
 // Mirrors the MatchingOperator enum in src/types.ts.
@@ -175,14 +184,15 @@ local promql = {
   clamp(params):: 'clamp(%s, %s, %s)' % [params.expr, params.min, params.max],
 
 
-  histogram_quantile(params):: 'histogram_quantile(%s, %s)' % [params.quantile, params.expr],
-  histogram_fraction(params):: 'histogram_quantile(%s, %s, %s)' % [params.lower, params.upper, params.expr],
+  histogram_quantile(params):: 'histogram_quantile(%s, %s)' % [histogramScalar(params.quantile), params.expr],
+  histogram_fraction(params):: 'histogram_fraction(%s, %s, %s)'
+                               % [histogramScalar(params.lower), histogramScalar(params.upper), params.expr],
 
   histogram_avg(params):: 'histogram_avg(%s)' % [params.expr],
-  histogram_sum(params):: 'histogram_avg(%s)' % [params.expr],
-  histogram_count(params):: 'histogram_avg(%s)' % [params.expr],
-  histogram_stddev(params):: 'histogram_avg(%s)' % [params.expr],
-  histogram_stdvar(params):: 'histogram_avg(%s)' % [params.expr],
+  histogram_sum(params):: 'histogram_sum(%s)' % [params.expr],
+  histogram_count(params):: 'histogram_count(%s)' % [params.expr],
+  histogram_stddev(params):: 'histogram_stddev(%s)' % [params.expr],
+  histogram_stdvar(params):: 'histogram_stdvar(%s)' % [params.expr],
 };
 
 // Composable PromQL metric selector with label matching.

--- a/jsonnet/promql.libsonnet
+++ b/jsonnet/promql.libsonnet
@@ -173,6 +173,16 @@ local promql = {
   clamp_min(params):: 'clamp_min(%s, %s)' % [params.expr, params.min],
   clamp_max(params):: 'clamp_max(%s, %s)' % [params.expr, params.max],
   clamp(params):: 'clamp(%s, %s, %s)' % [params.expr, params.min, params.max],
+
+
+  histogram_quantile(params):: 'histogram_quantile(%s, %s)' % [params.quantile, params.expr],
+  histogram_fraction(params):: 'histogram_quantile(%s, %s, %s)' % [params.lower, params.upper, params.expr],
+
+  histogram_avg(params):: 'histogram_avg(%s)' % [params.expr],
+  histogram_sum(params):: 'histogram_avg(%s)' % [params.expr],
+  histogram_count(params):: 'histogram_avg(%s)' % [params.expr],
+  histogram_stddev(params):: 'histogram_avg(%s)' % [params.expr],
+  histogram_stdvar(params):: 'histogram_avg(%s)' % [params.expr],
 };
 
 // Composable PromQL metric selector with label matching.

--- a/spec/fixtures/conformance.json
+++ b/spec/fixtures/conformance.json
@@ -1336,6 +1336,104 @@
       "error": "group_left/group_right require an \"on\" or \"ignoring\" clause"
     },
     {
+      "suite": "histogram",
+      "fn": "histogram_quantile",
+      "params": {
+        "expr": "rate(http_request_duration_seconds[5m])",
+        "quantile": 0.99
+      },
+      "expected": "histogram_quantile(0.99, rate(http_request_duration_seconds[5m]))"
+    },
+    {
+      "suite": "histogram",
+      "fn": "histogram_quantile",
+      "params": {
+        "expr": "rate(http_request_duration_seconds[5m])",
+        "quantile": "0.999999"
+      },
+      "expected": "histogram_quantile(0.999999, rate(http_request_duration_seconds[5m]))"
+    },
+    {
+      "suite": "histogram",
+      "fn": "histogram_fraction",
+      "params": {
+        "expr": "rate(http_request_duration_seconds[5m])",
+        "lower": 0.1,
+        "upper": 0.9
+      },
+      "expected": "histogram_fraction(0.1, 0.9, rate(http_request_duration_seconds[5m]))"
+    },
+    {
+      "suite": "histogram",
+      "fn": "histogram_fraction",
+      "params": {
+        "expr": "rate(http_request_duration_seconds[5m])",
+        "lower": "-Inf",
+        "upper": 0
+      },
+      "expected": "histogram_fraction(-Inf, 0, rate(http_request_duration_seconds[5m]))"
+    },
+    {
+      "suite": "histogram",
+      "fn": "histogram_fraction",
+      "params": {
+        "expr": "rate(http_request_duration_seconds[5m])",
+        "lower": 0,
+        "upper": "+Inf"
+      },
+      "expected": "histogram_fraction(0, +Inf, rate(http_request_duration_seconds[5m]))"
+    },
+    {
+      "suite": "histogram",
+      "fn": "histogram_fraction",
+      "params": {
+        "expr": "rate(http_request_duration_seconds[5m])",
+        "lower": "-Inf",
+        "upper": "+Inf"
+      },
+      "expected": "histogram_fraction(-Inf, +Inf, rate(http_request_duration_seconds[5m]))"
+    },
+    {
+      "suite": "histogram",
+      "fn": "histogram_avg",
+      "params": {
+        "expr": "rate(http_request_duration_seconds[5m])"
+      },
+      "expected": "histogram_avg(rate(http_request_duration_seconds[5m]))"
+    },
+    {
+      "suite": "histogram",
+      "fn": "histogram_sum",
+      "params": {
+        "expr": "rate(http_request_duration_seconds[5m])"
+      },
+      "expected": "histogram_sum(rate(http_request_duration_seconds[5m]))"
+    },
+    {
+      "suite": "histogram",
+      "fn": "histogram_count",
+      "params": {
+        "expr": "rate(http_request_duration_seconds[5m])"
+      },
+      "expected": "histogram_count(rate(http_request_duration_seconds[5m]))"
+    },
+    {
+      "suite": "histogram",
+      "fn": "histogram_stddev",
+      "params": {
+        "expr": "rate(http_request_duration_seconds[5m])"
+      },
+      "expected": "histogram_stddev(rate(http_request_duration_seconds[5m]))"
+    },
+    {
+      "suite": "histogram",
+      "fn": "histogram_stdvar",
+      "params": {
+        "expr": "rate(http_request_duration_seconds[5m])"
+      },
+      "expected": "histogram_stdvar(rate(http_request_duration_seconds[5m]))"
+    },
+    {
       "suite": "increase",
       "fn": "increase",
       "params": {

--- a/spec/fixtures/conformance.json
+++ b/spec/fixtures/conformance.json
@@ -914,6 +914,72 @@
       "expected": "((a == b) != c)"
     },
     {
+      "suite": "clamp",
+      "fn": "clamp_min",
+      "params": {
+        "expr": "foo{bar=\"baz\"}",
+        "min": 0
+      },
+      "expected": "clamp_min(foo{bar=\"baz\"}, 0)"
+    },
+    {
+      "suite": "clamp",
+      "fn": "clamp_min",
+      "params": {
+        "expr": "foo{bar=\"baz\"}",
+        "min": "$min"
+      },
+      "expected": "clamp_min(foo{bar=\"baz\"}, $min)"
+    },
+    {
+      "suite": "clamp",
+      "fn": "clamp_max",
+      "params": {
+        "expr": "foo{bar=\"baz\"}",
+        "max": 100
+      },
+      "expected": "clamp_max(foo{bar=\"baz\"}, 100)"
+    },
+    {
+      "suite": "clamp",
+      "fn": "clamp_max",
+      "params": {
+        "expr": "foo{bar=\"baz\"}",
+        "max": "$max"
+      },
+      "expected": "clamp_max(foo{bar=\"baz\"}, $max)"
+    },
+    {
+      "suite": "clamp",
+      "fn": "clamp",
+      "params": {
+        "expr": "foo{bar=\"baz\"}",
+        "min": -10,
+        "max": 100
+      },
+      "expected": "clamp(foo{bar=\"baz\"}, -10, 100)"
+    },
+    {
+      "suite": "clamp",
+      "fn": "clamp",
+      "params": {
+        "expr": "foo{bar=\"baz\"}",
+        "min": "$min",
+        "max": "$max"
+      },
+      "expected": "clamp(foo{bar=\"baz\"}, $min, $max)"
+    },
+    {
+      "suite": "clamp",
+      "fn": "clamp",
+      "params": {
+        "expr": "foo{bar=\"baz\"}",
+        "min": "0",
+        "max": "NaN"
+      },
+      "expected": "clamp(foo{bar=\"baz\"}, 0, NaN)"
+    },
+    {
       "suite": "comparisonBinaryOp",
       "fn": "eq",
       "params": {

--- a/spec/fixtures/conformance.json
+++ b/spec/fixtures/conformance.json
@@ -980,6 +980,16 @@
       "expected": "clamp(foo{bar=\"baz\"}, 0, NaN)"
     },
     {
+      "suite": "clamp",
+      "fn": "clamp",
+      "params": {
+        "expr": "foo{bar=\"baz\"}",
+        "min": 0.001,
+        "max": 0.1
+      },
+      "expected": "clamp(foo{bar=\"baz\"}, 0.001, 0.1)"
+    },
+    {
       "suite": "comparisonBinaryOp",
       "fn": "eq",
       "params": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,4 +20,10 @@ export type {
   ArithmeticBinaryOpParams,
   ComparisonBinaryOpParams,
   PrettifyOptions,
+  ClampMinParams,
+  ClampMaxParams,
+  ClampParams,
+  HistogramQuantileParams,
+  HistogramFractionParams,
+  ExprParam,
 } from './types';

--- a/src/promql.ts
+++ b/src/promql.ts
@@ -10,6 +10,9 @@ import {
   Offset,
   Rate,
   Increase,
+  ClampMinParams,
+  ClampMaxParams,
+  ClampParams,
 } from './types';
 import { buildOffsetString } from './utils';
 
@@ -110,4 +113,8 @@ export const promql = {
   lt: (params: ComparisonBinaryOpParams) => promql.binaryOp('<', params),
   gte: (params: ComparisonBinaryOpParams) => promql.binaryOp('>=', params),
   lte: (params: ComparisonBinaryOpParams) => promql.binaryOp('<=', params),
+
+  clamp_min: (params: ClampMinParams) => `clamp_min(${params.expr}, ${params.min})`,
+  clamp_max: (params: ClampMaxParams) => `clamp_max(${params.expr}, ${params.max})`,
+  clamp: (params: ClampParams) => `clamp(${params.expr}, ${params.min}, ${params.min})`,
 };

--- a/src/promql.ts
+++ b/src/promql.ts
@@ -116,5 +116,5 @@ export const promql = {
 
   clamp_min: (params: ClampMinParams) => `clamp_min(${params.expr}, ${params.min})`,
   clamp_max: (params: ClampMaxParams) => `clamp_max(${params.expr}, ${params.max})`,
-  clamp: (params: ClampParams) => `clamp(${params.expr}, ${params.min}, ${params.min})`,
+  clamp: (params: ClampParams) => `clamp(${params.expr}, ${params.min}, ${params.max})`,
 };

--- a/src/promql.ts
+++ b/src/promql.ts
@@ -13,6 +13,9 @@ import {
   ClampMinParams,
   ClampMaxParams,
   ClampParams,
+  HistogramQuantileParams,
+  HistogramFractionParams,
+  ExprParam,
 } from './types';
 import { buildOffsetString } from './utils';
 
@@ -117,4 +120,13 @@ export const promql = {
   clamp_min: (params: ClampMinParams) => `clamp_min(${params.expr}, ${params.min})`,
   clamp_max: (params: ClampMaxParams) => `clamp_max(${params.expr}, ${params.max})`,
   clamp: (params: ClampParams) => `clamp(${params.expr}, ${params.min}, ${params.max})`,
+
+  histogram_quantile: ({ expr, quantile }: HistogramQuantileParams) => `histogram_quantile(${quantile}, ${expr})`,
+  histogram_fraction: ({ expr, lower, upper }: HistogramFractionParams) => `histogram_fraction(${lower}, ${upper}, ${expr})`,
+  
+  histogram_avg: ({ expr }: ExprParam) => `histogram_avg(${expr})`,
+  histogram_sum: ({ expr }: ExprParam) => `histogram_sum(${expr})`,
+  histogram_count: ({ expr }: ExprParam) => `histogram_count(${expr})`,
+  histogram_stddev: ({ expr }: ExprParam) => `histogram_stddev(${expr})`,
+  histogram_stdvar: ({ expr }: ExprParam) => `histogram_stdvar(${expr})`,
 };

--- a/src/test/clamp.spec.ts
+++ b/src/test/clamp.spec.ts
@@ -1,0 +1,37 @@
+import { promql } from '../promql';
+
+// https://prometheus.io/docs/prometheus/latest/querying/functions/#clamp
+describe('Functions: clamp', () => {
+  it.each([
+    {
+      actual: () => promql.clamp_min({ expr: 'foo{bar="baz"}', min: 0 }),
+      expected: 'clamp_min(foo{bar="baz"}, 0)',
+    },
+    {
+      actual: () => promql.clamp_min({ expr: 'foo{bar="baz"}', min: '$min' }),
+      expected: 'clamp_min(foo{bar="baz"}, $min)',
+    },
+    {
+      actual: () => promql.clamp_max({ expr: 'foo{bar="baz"}', max: 100 }),
+      expected: 'clamp_max(foo{bar="baz"}, 100)',
+    },
+    {
+      actual: () => promql.clamp_max({ expr: 'foo{bar="baz"}', max: '$max' }),
+      expected: 'clamp_max(foo{bar="baz"}, $max)',
+    },
+    {
+      actual: () => promql.clamp({ expr: 'foo{bar="baz"}', min: -10, max: 100 }),
+      expected: 'clamp(foo{bar="baz"}, -10, 100)',
+    },
+    {
+      actual: () => promql.clamp({ expr: 'foo{bar="baz"}', min: '$min', max: '$max' }),
+      expected: 'clamp(foo{bar="baz"}, $min, $max)',
+    },
+    {
+      actual: () => promql.clamp({ expr: 'foo{bar="baz"}', min: '0', max: 'NaN' }),
+      expected: 'clamp(foo{bar="baz"}, 0, NaN)',
+    },
+  ])('Generate PromQL clamp query: $expected', ({ actual, expected }) => {
+    expect(actual()).toStrictEqual(expected);
+  });
+});

--- a/src/test/clamp.spec.ts
+++ b/src/test/clamp.spec.ts
@@ -31,6 +31,10 @@ describe('Functions: clamp', () => {
       actual: () => promql.clamp({ expr: 'foo{bar="baz"}', min: '0', max: 'NaN' }),
       expected: 'clamp(foo{bar="baz"}, 0, NaN)',
     },
+    {
+      actual: () => promql.clamp({ expr: 'foo{bar="baz"}', min: 0.001, max: 0.1 }),
+      expected: 'clamp(foo{bar="baz"}, 0.001, 0.1)',
+    },
   ])('Generate PromQL clamp query: $expected', ({ actual, expected }) => {
     expect(actual()).toStrictEqual(expected);
   });

--- a/src/test/histogram.spec.ts
+++ b/src/test/histogram.spec.ts
@@ -1,0 +1,55 @@
+import { promql } from '../promql';
+
+// https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile
+describe('Functions: histogram', () => {
+  const histogramExpr = 'rate(http_request_duration_seconds[5m])';
+
+  it.each([
+    {
+      actual: () => promql.histogram_quantile({ expr: histogramExpr, quantile: 0.99 }),
+      expected: 'histogram_quantile(0.99, rate(http_request_duration_seconds[5m]))',
+    },
+    {
+      actual: () => promql.histogram_quantile({ expr: histogramExpr, quantile: '0.999999' }),
+      expected: 'histogram_quantile(0.999999, rate(http_request_duration_seconds[5m]))',
+    },
+    {
+      actual: () => promql.histogram_fraction({ expr: histogramExpr, lower: 0.1, upper: 0.9 }),
+      expected: 'histogram_fraction(0.1, 0.9, rate(http_request_duration_seconds[5m]))',
+    },
+    {
+      actual: () => promql.histogram_fraction({ expr: histogramExpr, lower: '-Inf', upper: 0 }),
+      expected: 'histogram_fraction(-Inf, 0, rate(http_request_duration_seconds[5m]))',
+    },
+    {
+      actual: () => promql.histogram_fraction({ expr: histogramExpr, lower: 0, upper: '+Inf' }),
+      expected: 'histogram_fraction(0, +Inf, rate(http_request_duration_seconds[5m]))',
+    },
+    {
+      actual: () => promql.histogram_fraction({ expr: histogramExpr, lower: '-Inf', upper: '+Inf' }),
+      expected: 'histogram_fraction(-Inf, +Inf, rate(http_request_duration_seconds[5m]))',
+    },
+    {
+      actual: () => promql.histogram_avg({ expr: histogramExpr }),
+      expected: 'histogram_avg(rate(http_request_duration_seconds[5m]))',
+    },
+    {
+      actual: () => promql.histogram_sum({ expr: histogramExpr }),
+      expected: 'histogram_sum(rate(http_request_duration_seconds[5m]))',
+    },
+    {
+      actual: () => promql.histogram_count({ expr: histogramExpr }),
+      expected: 'histogram_count(rate(http_request_duration_seconds[5m]))',
+    },
+    {
+      actual: () => promql.histogram_stddev({ expr: histogramExpr }),
+      expected: 'histogram_stddev(rate(http_request_duration_seconds[5m]))',
+    },
+    {
+      actual: () => promql.histogram_stdvar({ expr: histogramExpr }),
+      expected: 'histogram_stdvar(rate(http_request_duration_seconds[5m]))',
+    },
+  ])('Generate PromQL histogram query: $expected', ({ actual, expected }) => {
+    expect(actual()).toStrictEqual(expected);
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -153,3 +153,21 @@ export type ClampMaxParams = {
 
 /** Parameters for the clamp function */
 export type ClampParams =  ClampMinParams & ClampMaxParams;
+
+export type ExprParam = {
+  /** An expr */
+  expr: string;
+}
+
+export type HistogramQuantileParams = ExprParam & {
+  /** The quantile/percentile represented as value between 0 and 1 */
+  quantile: number | string;
+}
+
+export type HistogramFractionParams = ExprParam & {
+  //** Lower boundary for observations to include, can also be -Inf */
+  lower: number | string;
+
+  //** Upper boundary for observations to include, can also be +Inf */
+  upper: number | string;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,3 +132,24 @@ export type PrettifyOptions = {
   /** maximum line width before an expression is broken onto multiple lines; defaults to 80 */
   maxWidth?: number;
 };
+
+/** Parameters for the clamp_min function */
+export type ClampMinParams = {
+  /** the expression to clamp */
+  expr: string;
+
+  /* the lower limit to clamp to */
+  min: number | string;
+}
+
+/** Parameters for the clamp_max function */
+export type ClampMaxParams = {
+  /** the expression to clamp */
+  expr: string;
+
+  /* the upper limit to clamp to */
+  max: number | string;
+}
+
+/** Parameters for the clamp function */
+export type ClampParams =  ClampMinParams & ClampMaxParams;


### PR DESCRIPTION
Adds support for a few additional functions:

* [clamp_min](https://prometheus.io/docs/prometheus/latest/querying/functions/#clamp_min)
* [clamp_max](https://prometheus.io/docs/prometheus/latest/querying/functions/#clamp_max)
* [clamp](https://prometheus.io/docs/prometheus/latest/querying/functions/#clamp)
* [histogram_quantile](https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile)
* [histogram_fraction](https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_fraction)
* [histogram_avg](https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_avg)
* [histogram_sum](https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_sum)
* [histogram_count](https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_count)
* [histogram_stddev](https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_stddev)
* [histogram_stdvar](https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_stdvar)